### PR TITLE
Emit ranking.json for external load balancers (loom + lean-genius)

### DIFF
--- a/menubar-app/ClaudeMonitor/Sources/RankingExporter.swift
+++ b/menubar-app/ClaudeMonitor/Sources/RankingExporter.swift
@@ -1,0 +1,321 @@
+import Foundation
+
+/// Emits `~/.claude-monitor/ranking.json` — a small, **non-secret**, email-keyed
+/// snapshot of per-account utilization / resets / status for external multi-account
+/// load balancers (loom, lean-genius). See issue #2.
+///
+/// Design contract:
+/// - **No secrets.** Only derived numbers (utilization, reset timestamps, status)
+///   are emitted. OAuth access/refresh tokens and raw API headers are never read
+///   into this file. The only join key is `email`.
+/// - **Atomic.** The file is written with `Data.write(options: .atomic)` (temp file
+///   in the same directory + rename) so consumers never observe a partial/truncated
+///   document.
+/// - **Best-effort.** A failure to read any single account, or to open the DB, must
+///   not crash the app — the exporter logs and returns. Optional data (the `models`
+///   / Fable field, backed by the externally-populated `probe_snapshots` table) is
+///   simply omitted when unavailable rather than failing the whole export.
+///
+/// ### Schema v1
+/// ```json
+/// {
+///   "schema": 1,
+///   "generated_at": "2026-01-01T00:00:00Z",
+///   "accounts": [
+///     {
+///       "email": "user@example.com",
+///       "plan": "max_20x",
+///       "status": "available",
+///       "utilization": { "5h": 0.12, "7d": 0.44 },
+///       "resets":      { "5h": "2026-01-01T02:00:00Z", "7d": "2026-01-04T00:00:00Z" },
+///       "models":      { "fable": { "utilization": 0.30 } },
+///       "updated_at":  "2026-01-01T00:00:00Z"
+///     }
+///   ]
+/// }
+/// ```
+enum RankingExporter {
+    static let schemaVersion = 1
+
+    /// Serializes exports so overlapping poll cycles never race on the write.
+    private static let queue = DispatchQueue(label: "com.claude-monitor.ranking-exporter")
+
+    private static var dbPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude-monitor/usage.db").path
+    }
+
+    private static var outputPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude-monitor/ranking.json").path
+    }
+
+    /// Trigger a fresh export. Runs off the caller's thread (DB reads + file IO)
+    /// on a dedicated serial queue so it never blocks the UI or races with itself.
+    static func export() {
+        queue.async { exportSync() }
+    }
+
+    // MARK: - Status mapping
+
+    /// Maps the app's ping signals to the schema's `status` enum. Explicit and
+    /// documented per issue #2:
+    ///
+    /// | Condition                                              | status         |
+    /// |--------------------------------------------------------|----------------|
+    /// | account has no active OAuth credential (`is_active=0`) | `blocked`      |
+    /// | weekly (`7d`) status is `rejected`                     | `exhausted`    |
+    /// | session (`5h`) or overall status is `rejected`         | `rate_limited` |
+    /// | `allowed` / `allowed_warning` / unknown                | `available`    |
+    ///
+    /// Weekly-rejected is treated as `exhausted` (the 7d quota is spent and resets
+    /// on a multi-day cadence); a session-only rejection is `rate_limited` (the 5h
+    /// window is temporarily full and resets soon).
+    static func mapStatus(
+        overallStatus: String?,
+        sessionStatus: String?,
+        weeklyStatus: String?,
+        credentialActive: Bool
+    ) -> String {
+        if !credentialActive { return "blocked" }
+        if weeklyStatus == "rejected" { return "exhausted" }
+        if sessionStatus == "rejected" || overallStatus == "rejected" { return "rate_limited" }
+        return "available"
+    }
+
+    // MARK: - Export implementation
+
+    private static func exportSync() {
+        guard FileManager.default.fileExists(atPath: dbPath) else { return }
+
+        do {
+            let db = try openDatabase(dbPath, readonly: true)
+
+            var accountObjects: [[String: Any]] = []
+
+            // Only non-secret columns are read. `accounts` carries no tokens.
+            let accountStmt = try db.prepare(
+                "SELECT id, email, plan FROM accounts ORDER BY sort_order ASC, last_updated DESC"
+            )
+
+            for row in accountStmt {
+                guard let accountId = row[0] as? String else { continue }
+                // Acceptance criterion: accounts with a NULL email are excluded
+                // (email is the sole join key — a null key is useless to consumers).
+                guard let email = row[1] as? String, !email.isEmpty else { continue }
+                let plan = row[2] as? String
+
+                if let obj = buildAccount(db: db, accountId: accountId, email: email, plan: plan) {
+                    accountObjects.append(obj)
+                }
+            }
+
+            let payload: [String: Any] = [
+                "schema": schemaVersion,
+                "generated_at": iso8601(Date()),
+                "accounts": accountObjects,
+            ]
+
+            let data = try JSONSerialization.data(
+                withJSONObject: payload,
+                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            )
+
+            // Ensure the parent dir exists (it normally does — the DB lives there).
+            let dir = (outputPath as NSString).deletingLastPathComponent
+            try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+
+            // Atomic write: Data.write(.atomic) stages a temp file in the same
+            // directory and renames it into place, so readers never see a partial file.
+            try data.write(to: URL(fileURLWithPath: outputPath), options: .atomic)
+        } catch {
+            FileLogger.shared.error("RankingExporter export failed: \(error)", category: "Ranking")
+        }
+    }
+
+    /// Build one account entry, or `nil` if the account should be skipped.
+    private static func buildAccount(
+        db: Connection,
+        accountId: String,
+        email: String,
+        plan: String?
+    ) -> [String: Any]? {
+        var obj: [String: Any] = ["email": email]
+        if let plan = plan { obj["plan"] = plan }
+
+        // Latest real (non-synthetic) usage reading for this account.
+        var sessionPercent: Double?
+        var weeklyPercent: Double?
+        var sessionReset: String?
+        var weeklyReset: String?
+        var rawData: String?
+        var updatedAt: String?
+
+        if let usageStmt = try? db.prepare("""
+            SELECT timestamp, session_percent, weekly_all_percent, session_reset, weekly_reset, raw_data
+            FROM usage_history
+            WHERE account_id = ? AND is_synthetic = 0
+            ORDER BY timestamp DESC LIMIT 1
+        """) {
+            for r in usageStmt.bind(accountId) {
+                updatedAt = r[0] as? String
+                sessionPercent = r[1] as? Double
+                weeklyPercent = r[2] as? Double
+                sessionReset = r[3] as? String
+                weeklyReset = r[4] as? String
+                rawData = r[5] as? String
+            }
+        }
+
+        // Parse the per-poll status blob written by OAuthPoller.writePingToDB().
+        let statuses = parseStatuses(rawData)
+        let credentialActive = isCredentialActive(db: db, accountId: accountId)
+
+        obj["status"] = mapStatus(
+            overallStatus: statuses.overall,
+            sessionStatus: statuses.session,
+            weeklyStatus: statuses.weekly,
+            credentialActive: credentialActive
+        )
+
+        // utilization: DB stores 0–100 percentages; schema wants 0.0–1.0 fractions.
+        var utilization: [String: Any] = [:]
+        if let s = sessionPercent { utilization["5h"] = fraction(s) }
+        if let w = weeklyPercent { utilization["7d"] = fraction(w) }
+        if !utilization.isEmpty { obj["utilization"] = utilization }
+
+        // resets: pass through the stored ISO 8601 strings, normalizing to UTC.
+        var resets: [String: Any] = [:]
+        if let s = normalizedISO(sessionReset) { resets["5h"] = s }
+        if let w = normalizedISO(weeklyReset) { resets["7d"] = w }
+        if !resets.isEmpty { obj["resets"] = resets }
+
+        // models: optional / best-effort. Omitted entirely when unavailable.
+        if let models = fableModels(db: db, accountId: accountId) {
+            obj["models"] = models
+        }
+
+        if let updatedAt = normalizedISO(updatedAt) {
+            obj["updated_at"] = updatedAt
+        }
+
+        return obj
+    }
+
+    // MARK: - Helpers
+
+    /// Whether the account has an active OAuth credential. Reads only the
+    /// non-secret `is_active` flag — never a token column. A missing table or
+    /// absent row is treated as "active" (we have no signal that it is blocked).
+    private static func isCredentialActive(db: Connection, accountId: String) -> Bool {
+        guard let stmt = try? db.prepare(
+            "SELECT is_active FROM oauth_credentials WHERE account_id = ? ORDER BY updated_at DESC LIMIT 1"
+        ) else { return true }
+        for r in stmt.bind(accountId) {
+            if let active = r[0] as? Int64 { return active != 0 }
+        }
+        return true
+    }
+
+    private struct Statuses { let overall: String?; let session: String?; let weekly: String? }
+
+    /// Parse the status blob stored in `usage_history.raw_data`. Two shapes exist
+    /// in the wild and both are tolerated:
+    ///   1. The compact form written by this repo's `OAuthPoller.writePingToDB()`:
+    ///      `{"ping_status":200,"session_status":"allowed","weekly_status":"allowed","overall_status":"allowed"}`
+    ///   2. The full response-header form written by the external poller that
+    ///      populates the live DB, keyed by the raw `anthropic-ratelimit-unified-*`
+    ///      header names.
+    /// Only status *strings* (`allowed` / `allowed_warning` / `rejected`) are read —
+    /// never token or identity fields.
+    private static func parseStatuses(_ raw: String?) -> Statuses {
+        guard let raw = raw,
+              let data = raw.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return Statuses(overall: nil, session: nil, weekly: nil)
+        }
+        func str(_ keys: String...) -> String? {
+            for key in keys {
+                if let v = obj[key] as? String, !v.isEmpty { return v }
+            }
+            return nil
+        }
+        return Statuses(
+            overall: str("overall_status", "anthropic-ratelimit-unified-status"),
+            session: str("session_status", "anthropic-ratelimit-unified-5h-status"),
+            weekly: str("weekly_status", "anthropic-ratelimit-unified-7d-status")
+        )
+    }
+
+    /// Best-effort per-model utilization from the externally-populated
+    /// `probe_snapshots` table. This repo never creates or writes that table, so
+    /// every access is defensive: a missing table, missing row, or unparseable
+    /// headers simply yields `nil` and the `models` key is omitted. Returns a dict
+    /// shaped like `{ "fable": { "utilization": 0.30 } }` when data is available.
+    ///
+    /// Semantics: the value is the unified 5h utilization (0.0–1.0) observed in the
+    /// response headers of the most recent successful (HTTP 200) Fable-model probe.
+    /// Anthropic's unified rate-limit headers are account-scoped rather than truly
+    /// per-model, so this is "utilization seen while exercising the Fable model,"
+    /// not a separate Fable-only quota. It is an optional/extensible signal per the
+    /// schema's `models` note; consumers that don't understand it ignore it.
+    private static func fableModels(db: Connection, accountId: String) -> [String: Any]? {
+        // `prepare` throws if probe_snapshots doesn't exist — tolerated via try?.
+        guard let stmt = try? db.prepare("""
+            SELECT headers FROM probe_snapshots
+            WHERE account_id = ? AND probe_model LIKE '%fable%' AND http_status = 200
+            ORDER BY timestamp DESC LIMIT 1
+        """) else { return nil }
+
+        for r in stmt.bind(accountId) {
+            guard let headersJSON = r[0] as? String,
+                  let data = headersJSON.data(using: .utf8),
+                  let headers = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            if let util = parseDoubleValue(headers["anthropic-ratelimit-unified-5h-utilization"]) {
+                return ["fable": ["utilization": clampFraction(util)]]
+            }
+        }
+        return nil
+    }
+
+    /// Convert a 0–100 percentage to a 0.0–1.0 fraction, rounded to 4 decimals.
+    private static func fraction(_ percent: Double) -> Double {
+        let f = (percent / 100.0 * 10000).rounded() / 10000
+        return clampFraction(f)
+    }
+
+    private static func clampFraction(_ v: Double) -> Double {
+        min(max(v, 0.0), 1.0)
+    }
+
+    /// Accepts a header value that may already be a number or a numeric string.
+    private static func parseDoubleValue(_ value: Any?) -> Double? {
+        if let d = value as? Double { return d }
+        if let i = value as? Int64 { return Double(i) }
+        if let s = value as? String { return Double(s) }
+        return nil
+    }
+
+    /// Re-serialize a stored timestamp to ISO 8601 UTC (`...Z`). Tolerates the two
+    /// formats this codebase writes (with and without fractional seconds). Returns
+    /// `nil` for nil/empty/unparseable input so the key can be omitted.
+    private static func normalizedISO(_ stored: String?) -> String? {
+        guard let stored = stored, !stored.isEmpty else { return nil }
+        let withFraction = ISO8601DateFormatter()
+        withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = withFraction.date(from: stored) ?? ISO8601DateFormatter().date(from: stored) {
+            return iso8601(date)
+        }
+        return nil
+    }
+
+    /// Canonical ISO 8601 UTC string with no fractional seconds (e.g. `2026-01-01T00:00:00Z`).
+    private static func iso8601(_ date: Date) -> String {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f.string(from: date)
+    }
+}

--- a/menubar-app/ClaudeMonitor/Sources/main.swift
+++ b/menubar-app/ClaudeMonitor/Sources/main.swift
@@ -121,6 +121,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             await MainActor.run {
                 usageStore.loadFromDatabase()
                 updateStatusButton()
+                // Emit ~/.claude-monitor/ranking.json for external load balancers (#2)
+                RankingExporter.export()
                 flog.info("refreshAll: loaded \(usageStore.accounts.count) account(s)", category: "App")
             }
         }
@@ -134,6 +136,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 await MainActor.run {
                     usageStore.loadFromDatabase()
                     updateStatusButton()
+                    // Emit ~/.claude-monitor/ranking.json for external load balancers (#2)
+                    RankingExporter.export()
                 }
             }
         }


### PR DESCRIPTION
Closes #2

## Summary

Adds a `RankingExporter` that periodically emits **`~/.claude-monitor/ranking.json`** — a small, **non-secret**, email-keyed snapshot of per-account utilization / resets / status (schema v1) for external multi-account load balancers (loom `rjwalters/loom#3697`, lean-genius `rjwalters/lean-genius#41033`) to consume. claude-monitor stays a neutral data provider: it emits raw numbers, not a ranking policy.

## What changed

- **New `menubar-app/ClaudeMonitor/Sources/RankingExporter.swift`** — builds the schema-v1 document and writes it atomically.
- **`main.swift`** — invokes `RankingExporter.export()` right after `usageStore.loadFromDatabase()` in both `refreshAll()` and `refreshDue()`. No new timer; it rides the existing ~10-min poll cadence.

## Design / requirements

- **No secrets.** Reads only non-secret columns: `accounts(id,email,plan)`, `usage_history` (utilization percentages, reset timestamps, the small `raw_data` status blob) and, best-effort, `oauth_credentials.is_active`. OAuth access/refresh tokens are never read; raw headers are never emitted (only derived utilization numbers). `email` is the sole join key.
- **Atomic write.** `Data.write(to:options:.atomic)` (temp file in the same dir + rename), so consumers never observe a partial file. Runs on a dedicated serial queue off the UI thread.
- **Explicit status mapping** (documented in code): credential inactive → `blocked`; weekly `rejected` → `exhausted`; session/overall `rejected` → `rate_limited`; `allowed`/`allowed_warning`/unknown → `available`. `raw_data` parsing tolerates **both** the compact form this repo's `writePingToDB()` writes and the full `anthropic-ratelimit-unified-*` header form present in the live DB.
- **`models` (Fable) is optional / best-effort** from the externally-populated `probe_snapshots` table. Every access is defensive (`try?`): a missing table, missing row, or unparseable headers yields no `models` key rather than failing the export. Semantics documented in code (account-scoped unified 5h utilization observed during the most recent successful Fable-model probe).
- **Edge cases handled:** accounts with `NULL`/empty email are excluded (documented — email is the join key); accounts with no usage rows still emit an entry (status defaults to `available`); zero accounts → `"accounts": []`; utilization converted from stored 0–100 to 0.0–1.0; `resets`/`updated_at` normalized to ISO 8601 UTC.

## Verification

- `cd menubar-app/ClaudeMonitor && swift build` — passes (only pre-existing warnings in `OAuthPoller.swift`/`AnthropicAPI.swift`, untouched here).
- End-to-end: compiled a harness against a copy of the live DB. Output is valid schema-v1 JSON, status mapping correct (`available`/`exhausted` derived from real data), `models.fable` present where `probe_snapshots` had 200s and omitted otherwise, and a secret scan (`sk-ant`, `token`, `bearer`, `authorization`) of the produced file came back clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)