### PR TITLE
Add headless Linux mode: portable core + UI-less poll loop daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Headless mode / Linux support.** The package now builds on Linux
+  (`libsqlite3-dev` + Swift toolchain) as a UI-less daemon for Loom hosts: the
+  same poll loop (account-file sync, 10-min usage pings, 20-min Fable probes)
+  writing the same `~/.claude-monitor/usage.db` and `ranking.json`. On macOS
+  the loop is reachable via `ClaudeMonitor --headless`. Flags: `--once`,
+  `--interval <sec>`, `--version`; account list files are re-imported on
+  change while running. Includes a sample systemd unit
+  (`scripts/claude-monitor.service`). UI sources are fenced with
+  `#if os(macOS)`; a new `CSQLite` system-library target maps Linux's
+  libsqlite3, and rate-limit headers are now parsed from the lowercased
+  captured map (Linux `allHeaderFields` lookups are case-sensitive).
+
 - **App icon.** Custom gauge-dial icon (generated with
   [Imagine](https://github.com/rjwalters/imagine)); `Assets/AppIcon.icns` is
   now bundled by `build-macos-app.sh` and referenced via `CFBundleIconFile`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,21 @@
   open /Applications/ClaudeMonitor.app
   ```
 
+## Headless / Linux
+
+- The same package builds on Linux (`swift build` with `libsqlite3-dev` installed) as a headless daemon for Loom hosts — no UI, same poll loop, same `usage.db`/`ranking.json` outputs. See README "Headless Mode / Linux".
+- UI sources are fenced with `#if os(macOS)`; portable core must stay free of AppKit/SwiftUI/Combine/os.Logger. On Linux, `LinuxCompat.swift` shims `ObservableObject`/`@Published`, and `CSQLite/` maps the system libsqlite3 (macOS uses the SDK's `SQLite3` module).
+- Entry points: `main.swift` (macOS, dispatches to `HeadlessRunner` on `--headless`) and `HeadlessMain.swift` (Linux, always headless). Flags: `--once`, `--interval <sec>`, `--version`.
+- Parse response headers via `extractAnthropicHeaders` (lowercased map), never `allHeaderFields` subscripts — those are case-sensitive on Linux.
+- Verify Linux builds from macOS with the `swift:6.1` Docker image (`apt-get install libsqlite3-dev`, then `swift build`).
+
 ## Project Structure
 
 - `menubar-app/ClaudeMonitor/` - Swift Package Manager project
-  - `Sources/main.swift` - App entry point, AppDelegate, popover/window management
+  - `Sources/main.swift` - macOS entry point, AppDelegate, popover/window management
+  - `Sources/HeadlessMain.swift` / `Sources/HeadlessRunner.swift` - Linux entry point + UI-less poll loop (also `--headless` on macOS)
+  - `Sources/LinuxCompat.swift` - `ObservableObject`/`@Published` stand-ins for Linux (no Combine)
+  - `CSQLite/` - System-library target mapping Linux libsqlite3
   - `Sources/AnthropicAPI.swift` - API client (usage, profile, token refresh)
   - `Sources/OAuthPoller.swift` - Ping-based usage polling, token add/import, Fable probes
   - `Sources/UsagePopoverView.swift` - Summary-table popover, sortable headers, add-account dialog
@@ -28,6 +39,7 @@
   - `Sources/FileLogger.swift` - Debug log at `~/.claude-monitor/debug.log`
   - `Assets/` - App icon (`AppIcon.icns` + 1024px master PNG)
 - `scripts/build-macos-app.sh` - Build script that compiles and creates the .app bundle (bundles the icon)
+- `scripts/claude-monitor.service` - Sample systemd user unit for Linux headless mode
 - `build/` - Build output (ClaudeMonitor.app and .zip)
 
 ## Version Management

--- a/README.md
+++ b/README.md
@@ -205,6 +205,44 @@ When replacing `/Applications/ClaudeMonitor.app`, you must `rm -rf` the old
 bundle before copying — `cp -R` over a running app does not replace the
 binary. See `CLAUDE.md` for the exact sequence.
 
+## Headless Mode / Linux
+
+The same package builds on Linux as a headless daemon — no UI, same poll loop
+(account-file sync, 10-minute usage pings, 20-minute Fable probes) writing the
+same `~/.claude-monitor/usage.db` and `ranking.json`. This is what Loom hosts
+run.
+
+### Build (Linux)
+
+Requires a Swift toolchain ([swift.org](https://www.swift.org/install/) or the
+`swift:6.1` Docker image) and the SQLite dev headers:
+
+```bash
+sudo apt-get install libsqlite3-dev   # (yum: sqlite-devel)
+cd claude-monitor/menubar-app/ClaudeMonitor
+swift build -c release
+sudo cp .build/release/ClaudeMonitor /usr/local/bin/claude-monitor
+```
+
+### Run
+
+Put your accounts in `~/.claude-monitor/accounts.env`
+(`ACCOUNT_EMAIL_N` / `ACCOUNT_KEY_N` pairs, same format as the app's bulk
+import — see [Multiple Accounts](#multiple-accounts)), then:
+
+```bash
+claude-monitor                  # poll loop, logs to stdout + ~/.claude-monitor/debug.log
+claude-monitor --once           # one poll cycle, write ranking.json, exit
+claude-monitor --interval 300   # override per-account poll interval (seconds, min 60)
+```
+
+Edits to `accounts.env` / `accounts.local.env` are picked up automatically
+while the daemon runs. A sample systemd user unit is provided at
+`scripts/claude-monitor.service`.
+
+On macOS the same headless loop is available as `ClaudeMonitor --headless`
+(the bare binary or the app bundle's `Contents/MacOS/ClaudeMonitor`).
+
 ## Auto-Start on Login (Optional)
 
 ```bash
@@ -289,11 +327,14 @@ rm -rf /Applications/ClaudeMonitor.app
 
 ```
 claude-monitor/
-├── menubar-app/ClaudeMonitor/   # macOS menu-bar app (Swift Package)
+├── menubar-app/ClaudeMonitor/   # Swift Package: macOS menu-bar app + Linux headless daemon
 │   ├── Package.swift
 │   ├── Assets/                     # App icon (AppIcon.icns + 1024px master PNG)
+│   ├── CSQLite/                    # System-library shim mapping Linux libsqlite3
 │   └── Sources/
-│       ├── main.swift              # AppDelegate, menubar icon, popover wiring
+│       ├── main.swift              # macOS entry: AppDelegate, menubar icon, popover wiring
+│       ├── HeadlessMain.swift      # Linux entry (always headless)
+│       ├── HeadlessRunner.swift    # UI-less poll loop (Linux daemon / --headless on macOS)
 │       ├── UsageStore.swift        # SQLite store, settings, primary-account pin
 │       ├── SQLiteDB.swift          # Minimal system-libsqlite3 wrapper (zero deps)
 │       ├── UsagePopoverView.swift  # Summary table, sortable headers, add-account dialog
@@ -303,9 +344,11 @@ claude-monitor/
 │       ├── RollTokenView.swift     # Roll Token wizard window (rotate long-lived tokens)
 │       ├── TokenRoller.swift       # Revoke-all browser-console script generator
 │       ├── RankingExporter.swift   # Emits ~/.claude-monitor/ranking.json for load balancers
-│       └── FileLogger.swift        # Debug logging
+│       ├── FileLogger.swift        # Debug logging
+│       └── LinuxCompat.swift       # ObservableObject/@Published stand-ins for Linux
 └── scripts/
-    └── build-macos-app.sh          # Release build script
+    ├── build-macos-app.sh          # macOS release build script
+    └── claude-monitor.service      # Sample systemd user unit for Linux headless mode
 ```
 
 ## Related Projects

--- a/menubar-app/ClaudeMonitor/CSQLite/module.modulemap
+++ b/menubar-app/ClaudeMonitor/CSQLite/module.modulemap
@@ -1,0 +1,5 @@
+module CSQLite [system] {
+    header "shim.h"
+    link "sqlite3"
+    export *
+}

--- a/menubar-app/ClaudeMonitor/CSQLite/shim.h
+++ b/menubar-app/ClaudeMonitor/CSQLite/shim.h
@@ -1,0 +1,1 @@
+#include <sqlite3.h>

--- a/menubar-app/ClaudeMonitor/Package.swift
+++ b/menubar-app/ClaudeMonitor/Package.swift
@@ -7,8 +7,21 @@ let package = Package(
         .macOS(.v14)
     ],
     targets: [
+        // Linux has no SQLite3 SDK module; this system-library target maps the
+        // distro's libsqlite3 (apt: libsqlite3-dev). macOS uses the SDK module.
+        .systemLibrary(
+            name: "CSQLite",
+            path: "CSQLite",
+            providers: [
+                .apt(["libsqlite3-dev"]),
+                .yum(["sqlite-devel"])
+            ]
+        ),
         .executableTarget(
             name: "ClaudeMonitor",
+            dependencies: [
+                .target(name: "CSQLite", condition: .when(platforms: [.linux]))
+            ],
             path: "Sources",
             swiftSettings: [
                 .unsafeFlags(["-parse-as-library"])

--- a/menubar-app/ClaudeMonitor/Sources/AnthropicAPI.swift
+++ b/menubar-app/ClaudeMonitor/Sources/AnthropicAPI.swift
@@ -1,7 +1,8 @@
 import Foundation
-import os
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
-private let logger = Logger(subsystem: "com.claude-monitor.app", category: "AnthropicAPI")
 private let flog = FileLogger.shared
 private let fcat = "API"
 
@@ -130,23 +131,24 @@ class AnthropicAPIClient {
             throw AnthropicAPIError.httpError(status)
         }
 
-        let headers = httpResponse.allHeaderFields
-
-        let rawHeaders = Self.extractAnthropicHeaders(headers)
+        // Parse from the lowercased captured map, not allHeaderFields directly:
+        // on Linux allHeaderFields lookups are case-sensitive, so header-name
+        // casing from the server would otherwise change behavior per platform.
+        let rawHeaders = Self.extractAnthropicHeaders(httpResponse.allHeaderFields)
         Self.logUnknownHeaderKeys(rawHeaders.keys)
 
-        let orgId = headers["anthropic-organization-id"] as? String ?? ""
+        let orgId = rawHeaders["anthropic-organization-id"] ?? ""
 
         let pingResponse = PingResponse(
             organizationId: orgId,
             httpStatus: status,
-            sessionUtilization: parseDouble(headers["anthropic-ratelimit-unified-5h-utilization"]),
-            sessionReset: parseEpoch(headers["anthropic-ratelimit-unified-5h-reset"]),
-            sessionStatus: headers["anthropic-ratelimit-unified-5h-status"] as? String,
-            weeklyUtilization: parseDouble(headers["anthropic-ratelimit-unified-7d-utilization"]),
-            weeklyReset: parseEpoch(headers["anthropic-ratelimit-unified-7d-reset"]),
-            weeklyStatus: headers["anthropic-ratelimit-unified-7d-status"] as? String,
-            overallStatus: headers["anthropic-ratelimit-unified-status"] as? String,
+            sessionUtilization: parseDouble(rawHeaders["anthropic-ratelimit-unified-5h-utilization"]),
+            sessionReset: parseEpoch(rawHeaders["anthropic-ratelimit-unified-5h-reset"]),
+            sessionStatus: rawHeaders["anthropic-ratelimit-unified-5h-status"],
+            weeklyUtilization: parseDouble(rawHeaders["anthropic-ratelimit-unified-7d-utilization"]),
+            weeklyReset: parseEpoch(rawHeaders["anthropic-ratelimit-unified-7d-reset"]),
+            weeklyStatus: rawHeaders["anthropic-ratelimit-unified-7d-status"],
+            overallStatus: rawHeaders["anthropic-ratelimit-unified-status"],
             rawHeaders: rawHeaders
         )
 
@@ -276,7 +278,8 @@ class AnthropicAPIClient {
             throw AnthropicAPIError.httpError(httpResponse.statusCode)
         }
 
-        guard let orgId = httpResponse.allHeaderFields["anthropic-organization-id"] as? String, !orgId.isEmpty else {
+        let idHeaders = Self.extractAnthropicHeaders(httpResponse.allHeaderFields)
+        guard let orgId = idHeaders["anthropic-organization-id"], !orgId.isEmpty else {
             throw AnthropicAPIError.invalidResponse
         }
 
@@ -286,19 +289,12 @@ class AnthropicAPIClient {
 
     // MARK: - Helpers
 
-    private func parseDouble(_ value: Any?) -> Double? {
-        if let str = value as? String { return Double(str) }
-        if let num = value as? Double { return num }
-        if let num = value as? NSNumber { return num.doubleValue }
-        return nil
+    private func parseDouble(_ value: String?) -> Double? {
+        value.flatMap { Double($0) }
     }
 
-    private func parseEpoch(_ value: Any?) -> Date? {
-        let epoch: TimeInterval?
-        if let str = value as? String { epoch = TimeInterval(str) }
-        else if let num = value as? NSNumber { epoch = num.doubleValue }
-        else { return nil }
-        guard let epoch = epoch else { return nil }
+    private func parseEpoch(_ value: String?) -> Date? {
+        guard let epoch = value.flatMap({ TimeInterval($0) }) else { return nil }
         return Date(timeIntervalSince1970: epoch)
     }
 }

--- a/menubar-app/ClaudeMonitor/Sources/FileLogger.swift
+++ b/menubar-app/ClaudeMonitor/Sources/FileLogger.swift
@@ -5,6 +5,10 @@ import Foundation
 final class FileLogger {
     static let shared = FileLogger()
 
+    /// When true (headless mode), every line is also printed to stdout so
+    /// journald/docker logs capture it alongside the debug.log file.
+    var echoToStdout = false
+
     private let queue = DispatchQueue(label: "com.claude-monitor.file-logger")
     private let maxBytes: UInt64 = 1_048_576 // 1 MB
     private let logDir: String
@@ -27,6 +31,10 @@ final class FileLogger {
     func log(_ message: String, category: String = "App", level: Level = .info) {
         let ts = Self.formatter.string(from: Date())
         let line = "\(ts) [\(level.rawValue)] [\(category)] \(message)\n"
+        if echoToStdout {
+            print(line, terminator: "")
+            fflush(stdout)
+        }
         queue.async { [weak self] in
             self?.writeLine(line)
         }

--- a/menubar-app/ClaudeMonitor/Sources/HeadlessMain.swift
+++ b/menubar-app/ClaudeMonitor/Sources/HeadlessMain.swift
@@ -1,0 +1,11 @@
+#if !os(macOS)
+// Linux entry point: there is no UI, so the binary is always the headless
+// poll loop. (On macOS the entry lives in main.swift and dispatches here
+// when launched with --headless.)
+@main
+enum ClaudeMonitorEntry {
+    static func main() {
+        HeadlessRunner.main()
+    }
+}
+#endif

--- a/menubar-app/ClaudeMonitor/Sources/HeadlessRunner.swift
+++ b/menubar-app/ClaudeMonitor/Sources/HeadlessRunner.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// Headless poll loop — the AppDelegate cycle without any UI. This is the whole
+/// app on Linux (Loom hosts); on macOS it's reachable via `ClaudeMonitor
+/// --headless` for testing. Same behavior as the menubar app: import accounts
+/// from the account list files, ping each account on a 10-minute cadence, probe
+/// the Fable tier on a 20-minute cadence, and emit ranking.json after each
+/// round of polls. Additionally re-imports the account list files whenever
+/// their mtime changes, since a daemon has no "relaunch to pick up new
+/// accounts" moment.
+enum HeadlessRunner {
+    private static let flog = FileLogger.shared
+    private static let tickSeconds: UInt64 = 30
+
+    static func main() -> Never {
+        let args = CommandLine.arguments
+
+        if args.contains("--help") || args.contains("-h") {
+            print(usage)
+            exit(0)
+        }
+        if args.contains("--version") {
+            print("claude-monitor \(AppVersion.current)")
+            exit(0)
+        }
+
+        let once = args.contains("--once")
+
+        var pollInterval: TimeInterval? = nil
+        if let idx = args.firstIndex(of: "--interval") {
+            guard idx + 1 < args.count, let seconds = TimeInterval(args[idx + 1]), seconds >= 60 else {
+                FileHandle.standardError.write(Data("--interval requires a number of seconds (min 60)\n".utf8))
+                exit(2)
+            }
+            pollInterval = seconds
+        }
+
+        flog.echoToStdout = true
+
+        let store = UsageStore()
+        let poller = OAuthPoller()
+        if let pollInterval = pollInterval {
+            poller.pollInterval = pollInterval
+        }
+
+        Task {
+            await run(store: store, poller: poller, once: once)
+            exit(0)
+        }
+        dispatchMain()
+    }
+
+    private static func run(store: UsageStore, poller: OAuthPoller, once: Bool) async {
+        flog.info("claude-monitor headless v\(AppVersion.current) starting (poll interval \(Int(poller.pollInterval))s\(once ? ", single cycle" : ""))", category: "Headless")
+        store.ensureDatabase()
+
+        var filesStamp = accountFilesStamp()
+        let results = await poller.syncFromAccountFiles()
+        if !results.isEmpty {
+            let ok = results.filter { $0.success }.count
+            flog.info("Imported \(ok)/\(results.count) account(s) from account list files", category: "Headless")
+        }
+
+        await poller.pollAll()
+        _ = await poller.probeFableDue()
+        RankingExporter.exportNow()
+        logSummary(store: store)
+
+        if once { return }
+
+        while true {
+            try? await Task.sleep(nanoseconds: tickSeconds * 1_000_000_000)
+
+            // Pick up edits to accounts.env / accounts.local.env without a restart.
+            let stamp = accountFilesStamp()
+            if stamp != filesStamp {
+                filesStamp = stamp
+                flog.info("Account list files changed — re-importing", category: "Headless")
+                _ = await poller.syncFromAccountFiles()
+            }
+
+            let polled = await poller.pollDue()
+            let probed = await poller.probeFableDue()
+            if polled > 0 || probed > 0 {
+                RankingExporter.exportNow()
+                logSummary(store: store)
+            }
+        }
+    }
+
+    /// One log line per cycle so journald shows live state without the popover.
+    private static func logSummary(store: UsageStore) {
+        store.loadFromDatabase()
+        guard !store.accounts.isEmpty else {
+            flog.warning("No accounts configured — add ~/.claude-monitor/accounts.env (ACCOUNT_EMAIL_N/ACCOUNT_KEY_N pairs)", category: "Headless")
+            return
+        }
+        let parts = store.sortedAccountsForPopover.map { account -> String in
+            guard let usage = store.latestUsage[account.id] else { return "\(account.displayName): ?" }
+            let pct = Int(max(usage.sessionPercent ?? 0, usage.weeklyAllPercent ?? 0))
+            return "\(account.displayName): \(pct)%"
+        }
+        flog.info("Usage — " + parts.joined(separator: ", "), category: "Headless")
+    }
+
+    /// Concatenated mtimes of the account list files; changes when either is edited.
+    private static func accountFilesStamp() -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return ["accounts.env", "accounts.local.env"].map { name -> String in
+            let path = home.appendingPathComponent(".claude-monitor/\(name)").path
+            let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+            let mtime = (attrs?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+            return "\(name):\(mtime)"
+        }.joined(separator: ";")
+    }
+
+    private static let usage = """
+        claude-monitor headless — polls account usage and writes
+        ~/.claude-monitor/usage.db and ~/.claude-monitor/ranking.json.
+
+        Usage: ClaudeMonitor [--headless] [options]
+          (on Linux the binary is always headless; --headless is implied)
+
+        Options:
+          --once              Run one full poll cycle, export ranking.json, exit
+          --interval <sec>    Per-account poll interval in seconds (default 600, min 60)
+          --version           Print version and exit
+          --help              Show this help
+
+        Accounts are read from ~/.claude-monitor/accounts.env and
+        accounts.local.env (ACCOUNT_EMAIL_N / ACCOUNT_KEY_N pairs); edits are
+        picked up automatically while running.
+        """
+}

--- a/menubar-app/ClaudeMonitor/Sources/LinuxCompat.swift
+++ b/menubar-app/ClaudeMonitor/Sources/LinuxCompat.swift
@@ -1,0 +1,15 @@
+#if !canImport(Combine)
+// Minimal stand-ins for Combine's observation types so the portable core
+// (UsageStore, OAuthPoller, UpdateChecker) compiles on Linux. Headless mode
+// has no UI, so nothing ever observes these — plain storage is enough.
+
+protocol ObservableObject: AnyObject {}
+
+@propertyWrapper
+struct Published<Value> {
+    var wrappedValue: Value
+    init(wrappedValue: Value) {
+        self.wrappedValue = wrappedValue
+    }
+}
+#endif

--- a/menubar-app/ClaudeMonitor/Sources/OAuthPoller.swift
+++ b/menubar-app/ClaudeMonitor/Sources/OAuthPoller.swift
@@ -1,7 +1,5 @@
 import Foundation
-import os
 
-private let logger = Logger(subsystem: "com.claude-monitor.app", category: "OAuthPoller")
 private let flog = FileLogger.shared
 private let fcat = "OAuth"
 
@@ -435,8 +433,9 @@ class OAuthPoller: ObservableObject {
 
     // MARK: - Polling (each account once per interval, staggered)
 
-    /// How often each account should be polled (seconds)
-    private let pollInterval: TimeInterval = 600  // 10 minutes
+    /// How often each account should be polled (seconds). Headless mode may
+    /// override this via --interval; the app keeps the default.
+    var pollInterval: TimeInterval = 600  // 10 minutes
 
     /// Last poll time per credential ID
     private var lastPollTimes: [Int64: Date] = [:]

--- a/menubar-app/ClaudeMonitor/Sources/RankingExporter.swift
+++ b/menubar-app/ClaudeMonitor/Sources/RankingExporter.swift
@@ -56,6 +56,12 @@ enum RankingExporter {
         queue.async { exportSync() }
     }
 
+    /// Export and wait for the write to finish. Headless mode uses this so a
+    /// --once run can't exit before ranking.json lands on disk.
+    static func exportNow() {
+        queue.sync { exportSync() }
+    }
+
     // MARK: - Status mapping
 
     /// Maps the app's ping signals to the schema's `status` enum. Explicit and

--- a/menubar-app/ClaudeMonitor/Sources/RollTokenView.swift
+++ b/menubar-app/ClaudeMonitor/Sources/RollTokenView.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import AppKit
 import SwiftUI
 
@@ -294,3 +295,5 @@ final class RollTokenWindowController {
         NSApp.activate(ignoringOtherApps: true)
     }
 }
+
+#endif  // os(macOS)

--- a/menubar-app/ClaudeMonitor/Sources/SQLiteDB.swift
+++ b/menubar-app/ClaudeMonitor/Sources/SQLiteDB.swift
@@ -1,5 +1,9 @@
 import Foundation
+#if canImport(SQLite3)
 import SQLite3
+#else
+import CSQLite
+#endif
 
 /// Minimal wrapper over the system SQLite C API (libsqlite3 ships with macOS),
 /// mirroring the subset of the SQLite.swift API this app uses: raw SQL with `?`

--- a/menubar-app/ClaudeMonitor/Sources/TokenRoller.swift
+++ b/menubar-app/ClaudeMonitor/Sources/TokenRoller.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import AppKit
 import Foundation
 
@@ -73,3 +74,5 @@ enum TokenRoller {
         pb.setString("claude setup-token", forType: .string)
     }
 }
+
+#endif  // os(macOS)

--- a/menubar-app/ClaudeMonitor/Sources/UsageChartView.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageChartView.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import SwiftUI
 import Charts
 
@@ -1127,3 +1128,5 @@ class ChartWindowController {
         NSApp.activate(ignoringOtherApps: true)
     }
 }
+
+#endif  // os(macOS)

--- a/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import SwiftUI
 
 /// Format a time interval using a single unit with decreasing precision:
@@ -1137,3 +1138,5 @@ struct AddAccountView: View {
         }
     }
 }
+
+#endif  // os(macOS)

--- a/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
@@ -1,5 +1,7 @@
 import Foundation
-import AppKit
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Opens a SQLite connection with a busy timeout so concurrent access from
 /// other processes waits briefly for locks instead of failing immediately.

--- a/menubar-app/ClaudeMonitor/Sources/main.swift
+++ b/menubar-app/ClaudeMonitor/Sources/main.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import SwiftUI
 
 // MARK: - Popover Height Manager
@@ -48,6 +49,16 @@ class PopoverHeightManager: ObservableObject {
 }
 
 @main
+enum ClaudeMonitorEntry {
+    static func main() {
+        if CommandLine.arguments.contains("--headless") {
+            HeadlessRunner.main()
+        } else {
+            ClaudeMonitorApp.main()
+        }
+    }
+}
+
 struct ClaudeMonitorApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
@@ -388,3 +399,5 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
 }
+
+#endif  // os(macOS)

--- a/scripts/claude-monitor.service
+++ b/scripts/claude-monitor.service
@@ -1,0 +1,23 @@
+# systemd unit for claude-monitor headless mode (Linux / Loom hosts).
+#
+# Install:
+#   sudo cp ClaudeMonitor /usr/local/bin/claude-monitor
+#   cp scripts/claude-monitor.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now claude-monitor
+#
+# Logs: journalctl --user -u claude-monitor -f
+# (also written to ~/.claude-monitor/debug.log)
+
+[Unit]
+Description=Claude Monitor headless usage poller
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/claude-monitor
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Makes the Swift package build and run on Linux hosts as a headless daemon, as required for the Loom system (#8). Same poll loop as the menubar app — account-file sync, 10-minute usage pings, 20-minute Fable probes — writing the same `~/.claude-monitor/usage.db` and `ranking.json`, with no UI.

- UI sources fenced with `#if os(macOS)`; the portable core (API client, poller, store, SQLite wrapper, exporter, logger) has no AppKit/SwiftUI/Combine/os.Logger dependency
- New `HeadlessRunner` poll loop; Linux entry via `HeadlessMain.swift`, macOS testing via `ClaudeMonitor --headless`; flags `--once`, `--interval <sec>`, `--version`; account list files are re-imported when they change (a daemon has no relaunch moment)
- `CSQLite` system-library target maps Linux libsqlite3; macOS keeps the SDK `SQLite3` module; `LinuxCompat.swift` shims `ObservableObject`/`@Published`
- Bug fixed en route: rate-limit headers are now parsed from the lowercased captured map — `allHeaderFields` subscript lookups are case-sensitive on Linux and would have silently dropped every utilization value
- Sample systemd user unit at `scripts/claude-monitor.service`; README + CLAUDE.md document the Linux build; CHANGELOG entry added

## Verification

- macOS debug and release builds pass; `--headless --once` polled all 8 configured accounts end-to-end and refreshed `ranking.json`
- Linux (`swift:6.1` Docker + `libsqlite3-dev`): clean build; fresh-home run creates the full DB schema and exits 0; real-token run completed import → authenticated ping (org/utilization parsed correctly) → Fable probe 200 → complete `ranking.json`

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)