### PR TITLE
docs: note legacy pre-2.0 artifact cleanup in Uninstall (closes stale-CLI report)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,14 @@ rm -rf ~/.claude-monitor
 rm -rf /Applications/ClaudeMonitor.app
 ```
 
+### Upgrading from pre-2.0
+
+Versions before 2.0 shipped a Node CLI (`dist/cli.js`) that was removed in the 2.0 rewrite. Its build artifacts are untracked, so they linger in old checkouts and fail confusingly if run (e.g. `node dist/cli.js` errors with `ERR_MODULE_NOT_FOUND` for `commander`). Clean them up:
+
+```bash
+rm -rf dist node_modules
+```
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary

Issue #5 reported `node dist/cli.js` failing with `ERR_MODULE_NOT_FOUND` for `commander`. Curator investigation confirmed this is **not a current bug**: `dist/cli.js` is a stale, never-tracked build artifact from the pre-2.0 Node CLI, which was fully removed in 1698b03 (Feb 2026). The current repo is a pure-Swift menubar app with no Node CLI — the stale ESM artifact resolves against the new Loom workspace stub `package.json` and finds no installed `commander`, producing exactly the reported errors.

## Change

- Add an "Upgrading from pre-2.0" note under README's `## Uninstall` section instructing users of legacy checkouts to remove the leftover `dist/` and `node_modules/` directories.

Docs-only; no code or build changes. Verified via grep that no other references to `dist/cli.js`, `commander`, or a Node CLI exist in README.md, CLAUDE.md, or scripts/.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)