### PR TITLE
fix: update icon-master.source.json sha256 to match tracked PNG

### DIFF
--- a/menubar-app/ClaudeMonitor/Assets/icon-master.source.json
+++ b/menubar-app/ClaudeMonitor/Assets/icon-master.source.json
@@ -7,6 +7,7 @@
   "refs": [],
   "aspect_ratio": null,
   "size": null,
-  "sha256": "9adc48d500c3cb35b7f2301687254093f2846739cbfe076c4f257606e071c130",
-  "created": "2026-07-28T12:36:57-0700"
+  "sha256": "5a7e1f0abb644987665d3e4424fb4c2207dd1fe96c3b966b283294ba2ebb3733",
+  "created": "2026-07-28T12:36:57-0700",
+  "post_processing": "The imagine sidecar's raw sha256 (9adc48d5...) was for the unmasked model output. icon-master.png as committed is that output masked to a macOS squircle (see commit d5f47d7 'Add app icon (gauge dial) and bundle it at build time'), which changes the pixel/alpha data and therefore the hash. The sha256 above is recomputed against the tracked, post-processed icon-master.png so this recipe round-trips against the actual master."
 }


### PR DESCRIPTION
## Summary

`menubar-app/ClaudeMonitor/Assets/icon-master.source.json` recorded a sha256 that never matched the tracked `icon-master.png` — even at the commit that introduced both files (d5f47d7). This PR corrects the recorded hash and documents why they diverged.

## Investigation

- `git log --follow` shows `icon-master.png` and `icon-master.source.json` were both added in a single commit (d5f47d7, "Add app icon (gauge dial) and bundle it at build time") and never touched again — so this is not a case of the PNG being edited after the recipe was written; the hash was already stale at the moment of the original commit.
- The commit message says the icon was "generated with rjwalters/imagine (nano-banana-pro), **masked to a macOS squircle** and packaged as AppIcon.icns."
- The `imagine` CLI (`~/GitHub/imagine`) writes a `foo.png.json` sidecar recording the sha256 of the **raw model output** (`imagine/cli.py:126`). The recorded `sha256` (`9adc48d5…`) is that raw, pre-mask hash.
- The tracked `icon-master.png` is the **post-processed** (squircle-masked) result — a different set of pixel/alpha bytes than the raw generation, hence a different hash (`5a7e1f0a…`).

## Canonical side

The tracked `icon-master.png` is canonical: it's the file actually used to derive `AppIcon.icns` (via `sips`/`iconutil`) and ship in the app bundle. Regenerating the PNG from the recipe would only reproduce the pre-mask raw image and **lose** the squircle-masking step — there's no evidence the PNG itself is wrong or corrupted, only that the recipe's hash predates a legitimate post-processing step.

## Changes

- Updated `sha256` in `icon-master.source.json` to the actual hash of the committed `icon-master.png` (`shasum -a 256` verified to match).
- Added a `post_processing` field explaining the squircle-masking step that caused the original divergence, so this doesn't reoccur silently.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| Decide which side is canonical | ✅ | Tracked `icon-master.png` — it's the actual build input (see Investigation/Canonical side above) |
| Update recorded hash and note post-processing step | ✅ | `sha256` field updated + new `post_processing` field added; `shasum -a 256 icon-master.png` matches the recorded value |

## Test Plan

```bash
python3 -m json.tool icon-master.source.json   # valid JSON
shasum -a 256 icon-master.png                  # 5a7e1f0abb644987665d3e4424fb4c2207dd1fe96c3b966b283294ba2ebb3733
# matches the updated "sha256" field in icon-master.source.json
```

No Swift source changed; this is a metadata-only fix, so no build was required.

Closes #19