### PR TITLE
build: wire package.json check scripts to swift build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "private": true,
   "scripts": {
     "worktree:return": "./.loom/scripts/worktree-return.sh",
-    "check:ci": "echo 'No CI checks configured. Customize this script for your project.' && exit 0",
-    "check:all": "echo 'No checks configured. Customize this script for your project.' && exit 0",
-    "test": "echo 'No tests configured. Customize this script for your project.' && exit 0",
+    "check:ci": "cd menubar-app/ClaudeMonitor && swift build",
+    "check:all": "npm run check:ci && npm run test",
+    "test": "echo 'No Swift test target: menubar-app/ClaudeMonitor/Package.swift defines only the ClaudeMonitor executable target, no Tests/ directory. Correctness is verified by check:ci (swift build) plus the .github/workflows/build.yml CI build.' && exit 0",
     "lint": "echo 'No linter configured. Customize this script for your project.' && exit 0"
   }
 }


### PR DESCRIPTION
## Summary

The root `package.json` is a Loom-workspace stub whose `check:ci` / `check:all` /
`test` scripts were echo-only and always exited 0. Any build gate that runs them
(Loom's `buildGate`, or a human running `npm run check:ci` locally) passed
vacuously — a change that fails to compile could still look green. This wires
those scripts to the actual Swift package build so the gate is real.

## Changes

- `check:ci` now runs `cd menubar-app/ClaudeMonitor && swift build`, so it
  fails (non-zero exit) on compile errors instead of always succeeding.
- `test` documents why there is nothing to run: `Package.swift` defines only
  the `ClaudeMonitor` executable target, with no `Tests/` directory, so
  `swift test` would itself just error `no tests found`. The script explains
  this and points at `check:ci` (and the existing `.github/workflows/build.yml`
  CI build) as the actual correctness check.
- `check:all` composes `check:ci` then `test`.
- `lint` is left untouched (out of scope — no linter is configured for this
  Swift package, and the issue's acceptance criteria don't mention it).

The file itself is kept (per the issue: `.loom/scripts/{worktree,verify-install,
resync-installed,claude-wrapper}.sh` all read it), and its `name`/`version`
fields are untouched so `resync-installed.sh`'s targeted stub-version-field
edit still applies correctly if ever needed.

## Acceptance Criteria Verification

- [x] `check:ci` runs `swift build` in `menubar-app/ClaudeMonitor` (and fails on compile errors) — verified by running `npm run check:ci` both against a clean tree (`Build complete!`, exit 0) and after introducing a deliberate syntax error into `FileLogger.swift` (compiler errors printed, exit 1), then reverting.
- [x] `test` runs `swift test`, or documents why the package has no test target — confirmed via `swift test` directly: `error: no tests found; create a target in the 'Tests' directory`. The `test` script documents this instead of pretending to run tests.
- [x] `check:all` composes the above — verified `npm run check:all` runs `check:ci` then `test` and exits 0 on a clean tree.

## Test Plan

- `npm run check:ci` on a clean tree → `swift build` succeeds, exit 0.
- Introduced a deliberate syntax error in `Sources/FileLogger.swift`, ran `npm run check:ci` → compiler errors surfaced, exit 1 (confirms the gate is no longer vacuous). Reverted the test breakage before committing.
- `npm run test` → prints the no-test-target explanation, exit 0.
- `npm run check:all` on a clean tree → runs both, exit 0.
- Confirmed `git diff --stat` only touches `package.json`.

Closes #18