### PR TITLE
feat: headless CLI to export/import accounts + credentials for multi-host sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,47 @@ while the daemon runs. A sample systemd user unit is provided at
 On macOS the same headless loop is available as `ClaudeMonitor --headless`
 (the bare binary or the app bundle's `Contents/MacOS/ClaudeMonitor`).
 
+## Multi-Host Sync
+
+When multiple hosts each run their own `claude-monitor` (e.g. two Macs + a
+fleet of headless Linux workers), account records and OAuth credentials added
+on one host don't automatically appear on the others. `claude-monitor
+accounts export` / `import` is the blessed, headless-safe way to converge
+them — no GUI required, works identically on macOS and Linux:
+
+```bash
+# On the source host: dump account records + credentials to a file (0600).
+claude-monitor accounts export --output accounts.json
+
+# Copy it to each destination host over a trusted channel (scp, etc.),
+# then converge that host's own usage.db:
+claude-monitor accounts import accounts.json
+```
+
+- **What's synced:** account identity (id, name, email, plan) and OAuth
+  credentials (access/refresh tokens, expiry, scopes, plan tier). Usage
+  history, rankings, and poll status are **not** synced — those stay local to
+  each host's own polling.
+- **Idempotent, upsert-by-email:** `import` matches accounts by email
+  (falling back to id when email is absent), creates any account it doesn't
+  find locally, and updates the rest — except it **never regresses a newer
+  local record**: if the local `last_updated` is at least as recent as the
+  imported one, that account is left untouched. Safe to re-run against the
+  same file, and safe to import an older export after newer local polls.
+  `--dry-run` previews the account count without writing anything.
+- **Credentials are secrets:** the export is plaintext JSON containing live
+  OAuth tokens. `--output <path>` writes it with `0600` permissions and the
+  command prints a warning either way; without `--output` (stdout, e.g. for
+  `> accounts.json`) permissions aren't set for you — `chmod 600` the result,
+  transfer it over a trusted channel, and delete it once every destination
+  host has imported. Full at-rest/in-transit encryption (age, openssl) is a
+  natural next step but out of scope for the first pass here.
+- **No `--headless` flag needed** — `accounts export`/`import` are one-shot
+  operations, reachable directly on both platforms even from the macOS GUI
+  build: `ClaudeMonitor accounts export ...`.
+
+Run `claude-monitor accounts --help` for the full flag list.
+
 ## Auto-Start on Login (Optional)
 
 ```bash
@@ -448,6 +489,8 @@ claude-monitor/
 │       ├── main.swift              # macOS entry: AppDelegate, menubar icon, popover wiring
 │       ├── HeadlessMain.swift      # Linux entry (always headless)
 │       ├── HeadlessRunner.swift    # UI-less poll loop (Linux daemon / --headless on macOS)
+│       ├── AccountSync.swift       # accounts export/import: multi-host record + credential sync
+│       ├── AccountSyncCLI.swift    # `claude-monitor accounts export|import` CLI surface
 │       ├── UsageStore.swift        # SQLite store, settings, primary-account pin
 │       ├── SQLiteDB.swift          # Minimal system-libsqlite3 wrapper (zero deps)
 │       ├── UsagePopoverView.swift  # Summary table, sortable headers, add-account dialog

--- a/menubar-app/ClaudeMonitor/Sources/AccountSync.swift
+++ b/menubar-app/ClaudeMonitor/Sources/AccountSync.swift
@@ -1,0 +1,282 @@
+import Foundation
+
+/// Headless-safe account export/import for multi-host sync (issue #16). Reads
+/// and writes `~/.claude-monitor/usage.db` directly through `SQLiteDB.swift` —
+/// no AppKit/SwiftUI/Combine — so it works identically on macOS and Linux.
+///
+/// Export serializes account identity records plus their OAuth credentials
+/// (excluding host-local operational state: keychain refs, last_poll_at,
+/// last_error). Import upserts by email (falling back to id when email is
+/// absent), and never regresses a local record whose `last_updated` is newer
+/// than the imported one.
+///
+/// The exported bundle contains plaintext OAuth tokens — callers (see
+/// `AccountSyncCLI`) must treat it as a secret.
+enum AccountSync {
+    static let formatVersion = 1
+
+    struct ExportedCredential: Codable {
+        var label: String
+        var source: String
+        var accessToken: String?
+        var refreshToken: String?
+        var expiresAt: Int64?
+        var scopes: String?
+        var subscriptionType: String?
+        var rateLimitTier: String?
+        var isActive: Bool
+        var createdAt: String?
+        var updatedAt: String?
+        var tokenRolledAt: String?
+    }
+
+    struct ExportedAccount: Codable {
+        var id: String
+        var accountName: String?
+        var email: String?
+        var plan: String?
+        var lastUpdated: String?
+        var sortOrder: Int
+        var credentials: [ExportedCredential]
+    }
+
+    struct ExportBundle: Codable {
+        var formatVersion: Int
+        var exportedAt: String
+        var sourceHost: String
+        var accounts: [ExportedAccount]
+    }
+
+    enum SyncError: Error, LocalizedError {
+        case databaseMissing
+        case sqlite(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .databaseMissing:
+                return "No database found at ~/.claude-monitor/usage.db"
+            case .sqlite(let error):
+                return "Database error: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    /// `~/.claude-monitor/usage.db`, resolved the same way as
+    /// `UsageStore`/`OAuthPoller`. Every entry point below takes an explicit
+    /// `dbPath` (defaulting to this) so callers — including tests — can point
+    /// at an isolated database instead.
+    static var defaultDBPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude-monitor/usage.db").path
+    }
+
+    // MARK: - Export
+
+    static func exportBundle(dbPath: String = defaultDBPath) throws -> ExportBundle {
+        guard FileManager.default.fileExists(atPath: dbPath) else { throw SyncError.databaseMissing }
+        do {
+            let db = try openDatabase(dbPath, readonly: true)
+            var accounts: [ExportedAccount] = []
+
+            let acctStmt = try db.prepare(
+                "SELECT id, account_name, email, plan, last_updated, sort_order FROM accounts ORDER BY sort_order, id"
+            )
+            for row in acctStmt {
+                guard let id = row[0] as? String else { continue }
+
+                let credStmt = try db.prepare("""
+                    SELECT label, source, access_token, refresh_token, expires_at,
+                           scopes, subscription_type, rate_limit_tier, is_active,
+                           created_at, updated_at, token_rolled_at
+                    FROM oauth_credentials WHERE account_id = ?
+                """)
+                var credentials: [ExportedCredential] = []
+                for c in credStmt.bind(id) {
+                    credentials.append(ExportedCredential(
+                        label: (c[0] as? String) ?? id,
+                        source: (c[1] as? String) ?? "token",
+                        accessToken: c[2] as? String,
+                        refreshToken: c[3] as? String,
+                        expiresAt: c[4] as? Int64,
+                        scopes: c[5] as? String,
+                        subscriptionType: c[6] as? String,
+                        rateLimitTier: c[7] as? String,
+                        isActive: ((c[8] as? Int64) ?? 1) == 1,
+                        createdAt: c[9] as? String,
+                        updatedAt: c[10] as? String,
+                        tokenRolledAt: c[11] as? String
+                    ))
+                }
+
+                accounts.append(ExportedAccount(
+                    id: id,
+                    accountName: row[1] as? String,
+                    email: row[2] as? String,
+                    plan: row[3] as? String,
+                    lastUpdated: row[4] as? String,
+                    sortOrder: Int((row[5] as? Int64) ?? 0),
+                    credentials: credentials
+                ))
+            }
+
+            let now = ISO8601DateFormatter().string(from: Date())
+            return ExportBundle(
+                formatVersion: formatVersion,
+                exportedAt: now,
+                sourceHost: ProcessInfo.processInfo.hostName,
+                accounts: accounts
+            )
+        } catch let error as SyncError {
+            throw error
+        } catch {
+            throw SyncError.sqlite(error)
+        }
+    }
+
+    static func exportJSON(pretty: Bool = true, dbPath: String = defaultDBPath) throws -> Data {
+        let bundle = try exportBundle(dbPath: dbPath)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = pretty ? [.prettyPrinted, .sortedKeys] : [.sortedKeys]
+        return try encoder.encode(bundle)
+    }
+
+    // MARK: - Import
+
+    struct ImportOutcome {
+        let email: String?
+        let id: String
+        let action: Action
+
+        enum Action: String {
+            case created
+            case updated
+            case skippedNewer  // local record's last_updated is >= the imported one
+        }
+    }
+
+    struct ImportSummary {
+        var outcomes: [ImportOutcome] = []
+        var created: Int { outcomes.filter { $0.action == .created }.count }
+        var updated: Int { outcomes.filter { $0.action == .updated }.count }
+        var skipped: Int { outcomes.filter { $0.action == .skippedNewer }.count }
+    }
+
+    /// Upserts accounts by email (falling back to id when email is absent on
+    /// either side), skipping any account whose local `last_updated` is newer
+    /// than or equal to the imported record. Existing local ids are preserved
+    /// on match so `usage_history` / `probe_snapshots` rows stay attached.
+    @discardableResult
+    static func importBundle(_ bundle: ExportBundle, dbPath: String = defaultDBPath) throws -> ImportSummary {
+        guard FileManager.default.fileExists(atPath: dbPath) else { throw SyncError.databaseMissing }
+        do {
+            let db = try openDatabase(dbPath)
+            var summary = ImportSummary()
+            for account in bundle.accounts {
+                summary.outcomes.append(try importAccount(account, db: db))
+            }
+            return summary
+        } catch let error as SyncError {
+            throw error
+        } catch {
+            throw SyncError.sqlite(error)
+        }
+    }
+
+    private static func importAccount(_ account: ExportedAccount, db: Connection) throws -> ImportOutcome {
+        var existingId: String?
+        var existingLastUpdated: String?
+
+        if let email = account.email, !email.isEmpty {
+            let stmt = try db.prepare("SELECT id, last_updated FROM accounts WHERE email = ? LIMIT 1")
+            for r in stmt.bind(email) {
+                existingId = r[0] as? String
+                existingLastUpdated = r[1] as? String
+            }
+        }
+        if existingId == nil {
+            let stmt = try db.prepare("SELECT id, last_updated FROM accounts WHERE id = ? LIMIT 1")
+            for r in stmt.bind(account.id) {
+                existingId = r[0] as? String
+                existingLastUpdated = r[1] as? String
+            }
+        }
+
+        let isNewAccount = existingId == nil
+        let targetId = existingId ?? account.id
+
+        if !isNewAccount, isLocalAuthoritative(existingLastUpdated, incoming: account.lastUpdated) {
+            return ImportOutcome(email: account.email, id: targetId, action: .skippedNewer)
+        }
+
+        let now = ISO8601DateFormatter().string(from: Date())
+        let lastUpdated = account.lastUpdated ?? now
+
+        try db.run("""
+            INSERT INTO accounts (id, account_name, email, plan, last_updated, sort_order)
+            VALUES (?, ?, ?, ?, ?, COALESCE((SELECT MAX(sort_order) + 1 FROM accounts), 0))
+            ON CONFLICT(id) DO UPDATE SET
+                account_name = COALESCE(excluded.account_name, accounts.account_name),
+                email = COALESCE(excluded.email, accounts.email),
+                plan = COALESCE(excluded.plan, accounts.plan),
+                last_updated = excluded.last_updated
+        """, targetId, account.accountName, account.email, account.plan, lastUpdated)
+
+        for credential in account.credentials {
+            try importCredential(credential, accountId: targetId, db: db)
+        }
+
+        return ImportOutcome(email: account.email, id: targetId, action: isNewAccount ? .created : .updated)
+    }
+
+    private static func importCredential(_ credential: ExportedCredential, accountId: String, db: Connection) throws {
+        let now = ISO8601DateFormatter().string(from: Date())
+        let existingId = try db.scalar(
+            "SELECT id FROM oauth_credentials WHERE account_id = ? LIMIT 1", accountId
+        ) as? Int64
+        let existingToken = try db.scalar(
+            "SELECT access_token FROM oauth_credentials WHERE account_id = ? LIMIT 1", accountId
+        ) as? String
+
+        if let credId = existingId {
+            // Only bump token_rolled_at when the token value actually changes,
+            // mirroring saveCredentialForAccount's roll-clock semantics.
+            let tokenChanged = existingToken != credential.accessToken
+            try db.run("""
+                UPDATE oauth_credentials SET
+                    label = ?, source = ?, access_token = ?, refresh_token = ?,
+                    expires_at = ?, scopes = ?, subscription_type = ?, rate_limit_tier = ?,
+                    is_active = ?, updated_at = ?,
+                    token_rolled_at = CASE WHEN ? THEN ? ELSE token_rolled_at END
+                WHERE id = ?
+            """, credential.label, credential.source, credential.accessToken, credential.refreshToken,
+                 credential.expiresAt, credential.scopes, credential.subscriptionType, credential.rateLimitTier,
+                 credential.isActive, now, tokenChanged, credential.tokenRolledAt ?? now, credId)
+        } else {
+            try db.run("""
+                INSERT INTO oauth_credentials (
+                    account_id, label, source, access_token, refresh_token,
+                    expires_at, scopes, subscription_type, rate_limit_tier,
+                    is_active, created_at, updated_at, token_rolled_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, accountId, credential.label, credential.source, credential.accessToken, credential.refreshToken,
+                 credential.expiresAt, credential.scopes, credential.subscriptionType, credential.rateLimitTier,
+                 credential.isActive, credential.createdAt ?? now, now, credential.tokenRolledAt)
+        }
+    }
+
+    /// True if the local record should win: it has a timestamp at least as
+    /// recent as the incoming one, or the incoming record carries no
+    /// timestamp to compare against. False (incoming wins) when the local
+    /// record has no timestamp but the incoming one does.
+    private static func isLocalAuthoritative(_ existing: String?, incoming: String?) -> Bool {
+        guard let incoming = incoming, let incomingDate = parseISO(incoming) else { return true }
+        guard let existing = existing, let existingDate = parseISO(existing) else { return false }
+        return existingDate >= incomingDate
+    }
+
+    private static func parseISO(_ string: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: string) ?? ISO8601DateFormatter().date(from: string)
+    }
+}

--- a/menubar-app/ClaudeMonitor/Sources/AccountSyncCLI.swift
+++ b/menubar-app/ClaudeMonitor/Sources/AccountSyncCLI.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+/// `claude-monitor accounts export|import` — the CLI surface for `AccountSync`
+/// (issue #16). Reachable directly on both macOS and Linux without requiring
+/// `--headless` or any GUI code, so it works on headless Loom hosts.
+enum AccountSyncCLI {
+    /// `args` is everything after the `accounts` subcommand itself.
+    static func main(_ args: [String]) -> Never {
+        guard let sub = args.first else {
+            printUsage()
+            exit(2)
+        }
+
+        switch sub {
+        case "export":
+            runExport(Array(args.dropFirst()))
+        case "import":
+            runImport(Array(args.dropFirst()))
+        case "--help", "-h", "help":
+            printUsage()
+            exit(0)
+        default:
+            FileHandle.standardError.write(Data("Unknown 'accounts' subcommand '\(sub)'\n\n".utf8))
+            printUsage()
+            exit(2)
+        }
+    }
+
+    // MARK: - export
+
+    private static func runExport(_ args: [String]) -> Never {
+        var outputPath: String?
+        var pretty = true
+        var dbPath = AccountSync.defaultDBPath
+
+        var i = 0
+        while i < args.count {
+            switch args[i] {
+            case "--output", "-o":
+                guard i + 1 < args.count else { fail("--output requires a path") }
+                outputPath = args[i + 1]
+                i += 1
+            case "--compact":
+                pretty = false
+            case "--db":
+                guard i + 1 < args.count else { fail("--db requires a path") }
+                dbPath = args[i + 1]
+                i += 1
+            case "--help", "-h":
+                printUsage()
+                exit(0)
+            default:
+                fail("Unknown option '\(args[i])' (see --help)")
+            }
+            i += 1
+        }
+
+        do {
+            let data = try AccountSync.exportJSON(pretty: pretty, dbPath: dbPath)
+
+            FileHandle.standardError.write(Data("""
+                WARNING: this export contains OAuth access/refresh tokens in \
+                plaintext. Treat it as a credential: keep it off shared/world- \
+                readable storage, transfer it over a trusted channel, and \
+                delete it once the import completes.
+
+                """.utf8))
+
+            if let outputPath = outputPath {
+                try data.write(to: URL(fileURLWithPath: outputPath), options: .atomic)
+                try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: outputPath)
+                FileHandle.standardError.write(Data("Wrote \(data.count) bytes to \(outputPath) (mode 0600).\n".utf8))
+            } else {
+                FileHandle.standardError.write(Data("Writing to stdout — shell redirection does NOT set safe file permissions; run `chmod 600` on the result, or pass --output <path> instead.\n".utf8))
+                FileHandle.standardOutput.write(data)
+                FileHandle.standardOutput.write(Data("\n".utf8))
+            }
+            exit(0)
+        } catch {
+            fail("Export failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - import
+
+    private static func runImport(_ args: [String]) -> Never {
+        var path: String?
+        var dryRun = false
+        var dbPath = AccountSync.defaultDBPath
+
+        var i = 0
+        while i < args.count {
+            switch args[i] {
+            case "--dry-run":
+                dryRun = true
+            case "--db":
+                guard i + 1 < args.count else { fail("--db requires a path") }
+                dbPath = args[i + 1]
+                i += 1
+            case "--help", "-h":
+                printUsage()
+                exit(0)
+            default:
+                if path == nil, !args[i].hasPrefix("-") || args[i] == "-" {
+                    path = args[i]
+                } else {
+                    fail("Unknown option '\(args[i])' (see --help)")
+                }
+            }
+            i += 1
+        }
+
+        guard let path = path else {
+            fail("import requires a file path (or '-' for stdin)")
+        }
+
+        let data: Data
+        do {
+            data = (path == "-")
+                ? FileHandle.standardInput.readDataToEndOfFile()
+                : try Data(contentsOf: URL(fileURLWithPath: path))
+        } catch {
+            fail("Could not read '\(path)': \(error.localizedDescription)")
+        }
+
+        let bundle: AccountSync.ExportBundle
+        do {
+            bundle = try JSONDecoder().decode(AccountSync.ExportBundle.self, from: data)
+        } catch {
+            fail("Could not parse import file as an accounts bundle: \(error.localizedDescription)")
+        }
+
+        if dryRun {
+            print("Dry run: \(bundle.accounts.count) account(s) in bundle from '\(bundle.sourceHost)' (exported \(bundle.exportedAt)). No changes made.")
+            exit(0)
+        }
+
+        do {
+            let summary = try AccountSync.importBundle(bundle, dbPath: dbPath)
+            for outcome in summary.outcomes {
+                print("\(outcome.email ?? outcome.id): \(outcome.action.rawValue)")
+            }
+            print("Done: \(summary.created) created, \(summary.updated) updated, \(summary.skipped) skipped (local record was newer or equal).")
+            exit(0)
+        } catch {
+            fail("Import failed: \(error.localizedDescription)")
+        }
+    }
+
+    private static func fail(_ message: String) -> Never {
+        FileHandle.standardError.write(Data("Error: \(message)\n".utf8))
+        exit(1)
+    }
+
+    private static func printUsage() {
+        print("""
+            claude-monitor accounts — export/import account records + OAuth
+            credentials for multi-host sync (see README "Multi-Host Sync").
+
+            Usage:
+              claude-monitor accounts export [--output <path>] [--compact] [--db <path>]
+              claude-monitor accounts import <path|-> [--dry-run] [--db <path>]
+
+            export writes an accounts.json bundle (account records + OAuth
+            credentials) to stdout by default, or to --output <path> (written
+            with 0600 permissions). The bundle contains plaintext OAuth
+            tokens — treat it as a secret.
+
+            import upserts accounts by email (falling back to id when email
+            is absent), skipping any account whose local last_updated is
+            newer than or equal to the imported record — safe to re-run.
+            Reads from stdin when the path is '-'.
+
+            --db <path> overrides ~/.claude-monitor/usage.db (mainly for
+            testing/scripting against an alternate database).
+            """)
+    }
+}

--- a/menubar-app/ClaudeMonitor/Sources/HeadlessMain.swift
+++ b/menubar-app/ClaudeMonitor/Sources/HeadlessMain.swift
@@ -5,7 +5,13 @@
 @main
 enum ClaudeMonitorEntry {
     static func main() {
-        HeadlessRunner.main()
+        // `accounts export|import` is a one-shot CLI operation, distinct from
+        // the always-on poll loop below.
+        if CommandLine.arguments.dropFirst().first == "accounts" {
+            AccountSyncCLI.main(Array(CommandLine.arguments.dropFirst(2)))
+        } else {
+            HeadlessRunner.main()
+        }
     }
 }
 #endif

--- a/menubar-app/ClaudeMonitor/Sources/HeadlessRunner.swift
+++ b/menubar-app/ClaudeMonitor/Sources/HeadlessRunner.swift
@@ -130,5 +130,8 @@ enum HeadlessRunner {
         Accounts are read from ~/.claude-monitor/accounts.env and
         accounts.local.env (ACCOUNT_EMAIL_N / ACCOUNT_KEY_N pairs); edits are
         picked up automatically while running.
+
+        For multi-host sync of account records + credentials, see:
+          claude-monitor accounts --help
         """
 }

--- a/menubar-app/ClaudeMonitor/Sources/main.swift
+++ b/menubar-app/ClaudeMonitor/Sources/main.swift
@@ -51,7 +51,12 @@ class PopoverHeightManager: ObservableObject {
 @main
 enum ClaudeMonitorEntry {
     static func main() {
-        if CommandLine.arguments.contains("--headless") {
+        // `accounts export|import` is a one-shot CLI operation, not a launch
+        // mode — route it before the --headless/GUI dispatch so it works
+        // without also passing --headless.
+        if CommandLine.arguments.dropFirst().first == "accounts" {
+            AccountSyncCLI.main(Array(CommandLine.arguments.dropFirst(2)))
+        } else if CommandLine.arguments.contains("--headless") {
             HeadlessRunner.main()
         } else {
             ClaudeMonitorApp.main()


### PR DESCRIPTION
## Summary

- Adds `claude-monitor accounts export|import`, a Foundation-only CLI reachable directly on both macOS and Linux (no `--headless` flag or GUI code needed), implemented in `AccountSync.swift` (portable export/import logic against `usage.db` via `SQLiteDB.swift`) + `AccountSyncCLI.swift` (arg parsing, stdout/file output, warnings).
- `export` serializes account identity (id, name, email, plan) + OAuth credentials (access/refresh tokens, expiry, scopes, plan tier) to a JSON bundle — excludes host-local operational state (keychain refs, last_poll_at/last_error). `--output <path>` writes with `0600` permissions; either way a stderr warning flags the bundle as containing plaintext credentials.
- `import` upserts by email (falling back to id when email is absent), **preserving the existing local row id on match** so `usage_history`/`probe_snapshots` stay attached, and **never regresses an account whose local `last_updated` is newer than or equal to the imported record** — safe to re-run (idempotent).
- `--db <path>` override on both subcommands for scripting/testing against an alternate database.
- New README "Multi-Host Sync" section documents this as the blessed propagation path, replacing the manual sqlite-surgery + scp + hand-merge relay described in the issue.

## Scope decisions

- **Plaintext + 0600 + warning, not full encryption.** The issue explicitly framed encryption (age/openssl) as "a suggestion, not prescription." Given the scope, I implemented `0600` permissions on `--output` writes plus a loud stderr warning on every export (and an explicit callout that stdout redirection does *not* get safe permissions — `chmod 600` / `--output` recommended). Full at-rest/in-transit encryption is called out in the README as a natural next step, out of scope for this pass.
- **CLI shape deviates slightly from the issue's suggestion**: added `--output <path>` (vs. relying solely on shell redirection) so the tool can set `0600` itself, `--compact` for non-pretty JSON, `--dry-run` on import, and `--db <path>` for pointing at an alternate database (useful for tests/multi-profile scripting). The core two-verb shape (`accounts export` / `accounts import`) matches the issue.
- **Credential fields synced**: label, source, access/refresh token, expires_at, scopes, subscription_type, rate_limit_tier, is_active, created_at/updated_at, token_rolled_at. Deliberately excludes `keychain_service`/`keychain_account` (macOS Keychain refs, not portable) and `last_poll_at`/`last_error` (host-local operational state, not identity).
- No new test target was added (the package has none currently — restructuring into library+executable felt like more churn than this issue's scope warranted). Instead I did an end-to-end functional verification against isolated scratch SQLite databases (via the new `--db` override) covering: fresh-account round trip, idempotent re-import (all skip), local-newer-record protection (import skipped, local token preserved), and imported-newer-record update (local id preserved, credentials updated). Details in the PR discussion if useful.

## Verification

- `swift build` — clean, no warnings.
- Manual round-trip testing against scratch SQLite DBs (via `--db`) confirmed:
  - Fresh account created with token intact.
  - Local record newer than import → skipped, local token/id preserved.
  - Import newer than local → local id preserved, fields/credentials updated.
  - Re-running the same import → fully idempotent (0 created/updated, all skipped).
- Static check: `AccountSync.swift` / `AccountSyncCLI.swift` only `import Foundation` — no AppKit/SwiftUI/Combine/os.Logger — consistent with the portable-core constraint. (Docker-based Linux build verification wasn't possible in this environment — Docker daemon wasn't running — so this is unverified beyond the import-only static check; flagging for Judge/Doctor follow-up if that matters for merge.)

Closes #16