### PR TITLE
fix: backfill accounts.email from a well-formed account_name label

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,19 @@ sqlite3 ~/.claude-monitor/usage.db \
   "SELECT timestamp, primary_percent FROM usage_history ORDER BY timestamp DESC LIMIT 10;"
 ```
 
+**`accounts` table contract for external consumers:** `email` is the stable
+join key external tooling should key off of — notably `loom-daemon tokens
+import-from-monitor`, which matches accounts by `email` to build its token
+pool. `account_name` is a free-text, user-editable display label/alias and is
+**not** guaranteed to be an address (though it often is, since renaming an
+account to its own email is a common way to tell accounts apart in the UI).
+The app backfills `email` from `account_name` whenever the profile-derived
+email is unavailable but the label is itself a well-formed address — both at
+add/rename time and via a one-time healing migration on launch — so no account
+with valid credentials should persist indefinitely with `email = NULL`. If you
+ever see one, it means `account_name` isn't address-shaped either; there's no
+address for external tooling to recover.
+
 ## Uninstall
 
 ```bash

--- a/menubar-app/ClaudeMonitor/Sources/OAuthPoller.swift
+++ b/menubar-app/ClaudeMonitor/Sources/OAuthPoller.swift
@@ -3,6 +3,25 @@ import Foundation
 private let flog = FileLogger.shared
 private let fcat = "OAuth"
 
+/// A conservative "well-formed enough" email check — not full RFC 5322
+/// validation, just enough to distinguish a real address (e.g. one a user
+/// typed as an account label/alias) from an opaque account ID (a UUID/org ID,
+/// which never contains '@'). Used to backfill the `accounts.email` column —
+/// the join key `loom-daemon tokens import-from-monitor` uses to find
+/// accounts (#15) — whenever a profile-fetch-derived email is unavailable but
+/// the label plainly carries the address.
+func looksLikeEmailAddress(_ s: String) -> Bool {
+    guard !s.isEmpty, !s.contains(where: { $0.isWhitespace }) else { return false }
+    let parts = s.split(separator: "@", omittingEmptySubsequences: false)
+    guard parts.count == 2 else { return false }  // exactly one '@'
+    let local = parts[0]
+    let domain = parts[1]
+    guard !local.isEmpty, domain.contains("."), !domain.hasPrefix("."), !domain.hasSuffix(".") else {
+        return false
+    }
+    return true
+}
+
 // MARK: - Token Status
 
 enum TokenStatus: String {
@@ -275,6 +294,13 @@ class OAuthPoller: ObservableObject {
             let now = ISO8601DateFormatter().string(from: Date())
             let label = orgName ?? email ?? accountId
 
+            // When the profile/caller-supplied email is unavailable, fall back to
+            // the label itself if it's a well-formed address — an account must
+            // never persist indefinitely with email = NULL just because its
+            // profile fetch failed (or was never attempted) while the label
+            // plainly carries the address (#15).
+            let resolvedEmail = email ?? (looksLikeEmailAddress(label) ? label : nil)
+
             // Upsert account — never overwrite account_name (user may have renamed)
             try db.run("""
                 INSERT INTO accounts (id, account_name, email, plan, last_updated, sort_order)
@@ -283,7 +309,7 @@ class OAuthPoller: ObservableObject {
                     email = COALESCE(excluded.email, accounts.email),
                     plan = COALESCE(excluded.plan, accounts.plan),
                     last_updated = excluded.last_updated
-            """, accountId, label, email, plan, now)
+            """, accountId, label, resolvedEmail, plan, now)
 
             // Look for existing credential for THIS account
             let existingCred = try db.scalar(

--- a/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
@@ -227,8 +227,42 @@ class UsageStore: ObservableObject {
             // this — it's bumped on every poll — so we track token changes separately.
             // ADD COLUMN throws if it already exists; that's the expected no-op path.
             try? db.execute("ALTER TABLE oauth_credentials ADD COLUMN token_rolled_at TEXT")
+
+            // Migration: heal accounts left with email = NULL by earlier app
+            // versions — e.g. added via plain token paste (no email known) and
+            // later renamed to the real address, which only touched
+            // account_name. `email` is the join key downstream consumers (like
+            // loom-daemon's `tokens import-from-monitor`) key accounts on, so an
+            // account must never persist indefinitely without one (#15).
+            backfillMissingEmailsFromAccountName(db)
         } catch {
             FileLogger.shared.error("Failed to create database: \(error)", category: "DB")
+        }
+    }
+
+    /// One-time-per-launch healing pass: any account with `email IS NULL`
+    /// whose `account_name` is itself a well-formed address gets that address
+    /// copied into `email`. Idempotent and side-effect-free once every row is
+    /// backfilled — cheap enough to run unconditionally on every launch rather
+    /// than tracking a schema version for it.
+    private func backfillMissingEmailsFromAccountName(_ db: Connection) {
+        do {
+            let stmt = try db.prepare("SELECT id, account_name FROM accounts WHERE email IS NULL AND account_name IS NOT NULL")
+            var candidates: [(id: String, name: String)] = []
+            for row in stmt {
+                if let id = row[0] as? String, let name = row[1] as? String {
+                    candidates.append((id: id, name: name))
+                }
+            }
+            for candidate in candidates where looksLikeEmailAddress(candidate.name) {
+                try db.run("UPDATE accounts SET email = ? WHERE id = ? AND email IS NULL", candidate.name, candidate.id)
+                FileLogger.shared.info(
+                    "backfillMissingEmailsFromAccountName: healed email for account \(candidate.id) from account_name",
+                    category: "DB"
+                )
+            }
+        } catch {
+            FileLogger.shared.error("backfillMissingEmailsFromAccountName failed: \(error)", category: "DB")
         }
     }
 
@@ -684,13 +718,23 @@ class UsageStore: ObservableObject {
             let db = try openDatabase(dbPath)
             try db.run("UPDATE accounts SET account_name = ? WHERE id = ?", newName, accountId)
 
+            // Backfill email from a well-formed label — an account renamed to
+            // its real address must not keep email = NULL indefinitely just
+            // because a profile fetch never populated it (#15). Never
+            // overwrites an existing email.
+            var backfilledEmail: String?
+            if let newName, looksLikeEmailAddress(newName) {
+                try db.run("UPDATE accounts SET email = COALESCE(email, ?) WHERE id = ?", newName, accountId)
+                backfilledEmail = try db.scalar("SELECT email FROM accounts WHERE id = ?", accountId) as? String
+            }
+
             // Immediately update local state for instant UI feedback
             if let index = accounts.firstIndex(where: { $0.id == accountId }) {
                 let oldAccount = accounts[index]
                 let updatedAccount = Account(
                     id: oldAccount.id,
                     accountName: newName,
-                    email: oldAccount.email,
+                    email: backfilledEmail ?? oldAccount.email,
                     plan: oldAccount.plan,
                     lastUpdated: oldAccount.lastUpdated,
                     latestPercent: oldAccount.latestPercent


### PR DESCRIPTION
## Summary

Accounts could persist indefinitely with `email = NULL` even when their
`account_name` was itself a well-formed address. This broke `loom-daemon
tokens import-from-monitor`, which joins accounts on `email` — newly-added
capacity became silently invisible to the fleet.

## Root Cause

Root cause traced to two paths that only ever set `account_name`, never
`email`, and no backfill/retry existed:

1. **Add-time**: pasting a bare token (`UsagePopoverView.addToken()` →
   `OAuthPoller.addAccountWithToken(token)`) has no known email, so `email`
   is inserted as `NULL`.
2. **Rename-time**: `UsageStore.updateAccountName()` lets a user set a custom
   label/alias — commonly the account's own email address, to tell accounts
   apart in the UI — but only ever updated `account_name`, never `email`.

Once an account reaches state 2 (label = a real address, `email` still
`NULL`), nothing in the codebase retries or backfills `email` — it stays
`NULL` forever, as observed for `agent-6/7/8@2amlogic.com`.

## Changes

- `OAuthPoller.swift`: add a shared `looksLikeEmailAddress(_:)` conservative
  well-formed-address check (distinguishes a real address from an opaque
  account-ID/UUID label). Use it in the account upsert: when the
  caller-supplied `email` is unavailable, fall back to the label if it looks
  like an address.
- `UsageStore.swift`:
  - `updateAccountName()`: when renaming to a well-formed address, backfill
    `email` too (never overwrites an existing `email`), and reflect the
    backfill immediately in in-memory state for UI feedback.
  - `ensureDatabase()`: add a one-time-per-launch healing migration
    (`backfillMissingEmailsFromAccountName`) that copies `account_name` into
    `email` for any existing account stuck with `email IS NULL` where the
    label is address-shaped — this heals accounts already broken by earlier
    app versions (the exact scenario reported in #15), not just future ones.
- `README.md`: document the `accounts` table contract — `email` is the
  stable join key external tooling (`loom-daemon tokens import-from-monitor`)
  should key on; `account_name` is a free-text, user-editable label with no
  guarantee of being an address.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| When the profile email is unavailable and the label is a well-formed address, fall back to the label for `email` | ✅ | `resolvedEmail = email ?? (looksLikeEmailAddress(label) ? label : nil)` in the upsert (`OAuthPoller.swift`); rename-time backfill in `updateAccountName()` |
| No account with valid credentials can persist indefinitely with `email = NULL` | ✅ | Add three defenses: (1) add-time fallback, (2) rename-time backfill, (3) one-time launch migration that heals *already*-NULL rows — verified against a scratch sqlite DB seeded with the exact reported scenario (`account_name = 'agent-8@2amlogic.com'`, `email = NULL`); the migration query heals it while leaving a genuinely opaque UUID label untouched |
| (Nice to have) document the `accounts` table contract | ✅ | Added to `README.md` "Database" section |

## Test Plan

- `swift build` — clean build, no new warnings introduced (two pre-existing
  unrelated warnings in `AnthropicAPI.swift` about an unused `data` binding,
  untouched by this change).
- Verified `looksLikeEmailAddress` logic in isolation against 11 cases
  (well-formed addresses, a raw UUID label, missing local/domain parts,
  double `@`, leading/trailing dots, embedded whitespace, empty string) — all
  passed.
- Verified the migration SQL against a throwaway sqlite3 DB seeded with three
  rows mirroring the issue's reported state (a broken `agent-8@...` row, an
  already-correct row, and an opaque-UUID-label row) — only the broken row
  got healed, matching expected behavior.
- Did not run the built binary against a real `~/.claude-monitor/usage.db`
  for this PR (macOS's `homeDirectoryForCurrentUser` ignores a `$HOME`
  override, so an isolated end-to-end run isn't possible without touching a
  real account database).

Closes #15