### PR TITLE
ci: add Linux build job for the headless daemon target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [master, main]
 
 jobs:
-  build:
+  build-macos:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -16,3 +16,26 @@ jobs:
         run: |
           cd menubar-app/ClaudeMonitor
           swift build
+
+  build-linux:
+    runs-on: ubuntu-latest
+    container: swift:6.1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SQLite dev headers
+        run: apt-get update && apt-get install -y libsqlite3-dev
+
+      - name: Build (Linux headless)
+        run: |
+          cd menubar-app/ClaudeMonitor
+          swift build
+
+      - name: Smoke run (no credentials)
+        run: |
+          cd menubar-app/ClaudeMonitor
+          .build/debug/ClaudeMonitor --once
+          # The binary resolves home via homeDirectoryForCurrentUser (passwd
+          # entry), while Actions containers set HOME elsewhere — check both.
+          passwd_home=$(getent passwd "$(id -u)" | cut -d: -f6)
+          test -f "$passwd_home/.claude-monitor/usage.db" || test -f "$HOME/.claude-monitor/usage.db"


### PR DESCRIPTION
Closes #13

Adds a `build-linux` CI job covering the headless Linux target that Loom hosts run:

- Renames the existing job `build` → `build-macos` for clarity (repo has no required status checks pinned to the old name).
- New `build-linux` job on `ubuntu-latest` in the `swift:6.1` container: installs `libsqlite3-dev`, runs `swift build`, then a no-credentials smoke run (`.build/debug/ClaudeMonitor --once`) asserting `~/.claude-monitor/usage.db` is created.

Build was verified on macOS after rebasing onto main (post-#22); the Linux job validates itself on this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)