### PR TITLE
docs: write up static-analysis findings on ChatGPT/Codex usage probe

### DIFF
--- a/docs/spikes/2026-07-30-codex-usage-probe.md
+++ b/docs/spikes/2026-07-30-codex-usage-probe.md
@@ -1,0 +1,239 @@
+# Spike: can a cheap authenticated probe read ChatGPT/Codex subscription usage?
+
+Issue: #26 (part of the multi-provider epic, #25)
+Date: 2026-07-30
+
+## Question
+
+The app's Anthropic polling sends a 1-token Haiku message and reads the
+`anthropic-ratelimit-unified-*` response headers back. Is there an OpenAI
+equivalent for **ChatGPT subscription accounts** (Plus/Pro, as used by Codex
+CLI): a minimal authenticated request whose response carries session-window
+and weekly-window usage/reset data?
+
+## Short answer
+
+**Very likely yes, but not live-verified in this spike.** Static analysis of
+the shipped Codex CLI binary (v0.146.0) shows Codex CLI itself calls a
+dedicated usage/rate-limit endpoint and parses a response shape that is a very
+close analog of what we need — a list of rate-limit windows, each with a
+percent-used figure, a window size in minutes (letting the client tell a ~5h
+window apart from the weekly window), and a reset timestamp. That is enough
+to build the `AnthropicAPI`-equivalent provider client with high confidence
+in the target shape.
+
+What is **not** yet confirmed by live traffic is: the exact request path
+concatenation (base host + route), the exact JSON field names on the wire
+(the binary only gives us the internal Rust struct field names, which usually
+but not always match the wire JSON), and the real-world cost/rate-limit
+impact of calling it. See "What wasn't done, and why" below.
+
+## Credential situation on this host
+
+`~/.codex/auth.json` exists on this machine (Codex CLI 0.146.0 is installed
+and logged in). Its structure (`auth_mode`, `tokens.{id_token,access_token,
+refresh_token,account_id}`, `last_refresh`) was inspected with redaction —
+the raw token strings and PII (email, name) were **not** printed to this
+write-up.
+
+Decoding the (already-issued, not modified) JWT claims to understand token
+shape revealed this is the **operator's personal, primary ChatGPT Pro
+account** (a personal Gmail address, `role: owner` on a `Personal`
+organization). The issue explicitly says:
+
+> Use a low-value/test account, NOT a primary account.
+
+Because the only credential available on this host is disqualified by that
+instruction, **no live network probe was made against `chatgpt.com` /
+`api.openai.com` with this credential.** This spike is therefore functionally
+in the same position as "no usable test credential" even though a credential
+file exists. A dedicated low-value/disposable ChatGPT account should be
+provisioned before the live-verification step below is attempted.
+
+(Process note for future spikes: when decoding JWT claims for structural
+inspection, redact **nested** PII fields too, not just top-level keys — a
+first redaction pass in this session missed the `email`/`name` claims nested
+under `https://api.openai.com/profile` and they briefly appeared in the
+agent's own transcript before being caught. No credential value was leaked,
+but it is exactly the failure class #16 warned about. Fixed for the second
+pass; flagging here so the next spike's redaction helper accounts for nested
+paths from the start.)
+
+## What was done instead: static analysis of the Codex CLI binary
+
+Since Codex CLI's own `/usage` TUI command displays 5h/weekly percentages,
+the binary itself has to parse *some* wire response into that shape. Rather
+than emit new authenticated network traffic, this spike ran `strings -a` over
+the installed binary (`/opt/homebrew/Caskroom/codex/0.146.0/bin/codex`, an
+aarch64 Mach-O) and grepped for the internal type names, JSON field names,
+and route strings the compiler embedded. This is fully reproducible by
+anyone with Codex CLI installed and requires no network access or
+credentials:
+
+```bash
+strings -a "$(readlink -f "$(command -v codex)")" > /tmp/codex_strings.txt
+grep -n "RateLimitWindow\|GetAccountRateLimits\|GetAccountTokenUsage" /tmp/codex_strings.txt
+```
+
+### Response shape (from embedded Rust/TS type metadata)
+
+```
+GetAccountRateLimitsResponse
+  rate_limits                  # Vec<RateLimitWindow>
+  rate_limits_by_limit_id       # map, keyed by a rate-limit id
+  rate_limit_reset_credits      # optional reset-credit info (see below)
+
+RateLimitWindow (3 fields)
+  used_percent                  # f64/percent
+  window_minutes                # window size in minutes — e.g. ~300 (5h) vs ~10080 (7d)
+  resets_at                     # reset timestamp
+
+GetAccountTokenUsageResponse
+  summary
+  daily_usage_buckets           # Vec<AccountTokenUsageDailyBucket>
+
+AccountTokenUsageDailyBucket
+  start_date
+  tokens
+```
+
+`RateLimitWindow.window_minutes` is the key field: it is exactly the
+mechanism that would let a client tell the "5h" window from the "weekly"
+window apart in a single response array, without two separate calls — a
+close structural analog of Anthropic's paired
+`anthropic-ratelimit-unified-{5h,7d}-*` headers, just shaped as an array of
+windows in a JSON body instead of a family of response headers.
+
+### Error strings confirming a dedicated, authenticated fetch (not header piggyback)
+
+```
+chatgpt authentication required to read rate limits
+codex account authentication required to read rate limits
+failed to fetch codex rate limits: no snapshots returned
+chatgpt authentication required to read token usage
+codex account authentication required to read token usage
+```
+
+This is an architecturally different approach from Anthropic's: Anthropic
+piggybacks rate-limit state on the headers of every response (including a
+throwaway 1-token completion); OpenAI/ChatGPT appears to expose it via a
+**separate, dedicated endpoint** the CLI calls independently (Codex CLI's own
+`/usage` TUI command triggers it). That's good news for probe cost — it
+implies we would not need to burn a completion request at all, just call the
+usage endpoint directly — but the exact cost/rate-limit accounting of calling
+it is unverified (see below).
+
+### Candidate route and host strings
+
+```
+https://chatgpt.com/backend-api/codex      # explicit full-URL constant found in the binary
+/api/codex/usage                            # route name, paired with:
+/wham/usage                                 # ...an alternate route name
+/api/codex/rate-limit-reset-credits
+/wham/rate-limit-reset-credits
+/api/codex/rate-limit-reset-credits/consume
+/wham/rate-limit-reset-credits/consume
+```
+
+Each route name shows up in **two** forms — an `/api/codex/...` form and a
+`/wham/...` form — which lines up with the two auth-mode error strings above
+("chatgpt authentication" vs "codex account authentication"): the CLI
+appears to route the same logical call through a different path prefix
+depending on whether the session is ChatGPT-OAuth-authenticated (this repo's
+case, `auth_mode: "chatgpt"`) or authenticated via an OpenAI-platform/"codex
+account" identity. **The exact base-host + path concatenation actually used
+for the ChatGPT-OAuth case was not confirmed** — static strings show the
+pieces but not how the HTTP client joins them at runtime. A `chatgpt-account-id`
+HTTP header name is also present in the binary and mirrors the
+`chatgpt_account_id` claim already present in the id/access token, so it is
+very likely sent per-request the way Anthropic's calls carry account
+identity in the bearer token alone.
+
+### Auth mechanics — the significant departure from the Anthropic model
+
+`~/.codex/auth.json` holds three JWTs plus a UUID:
+
+| Field | Purpose | Lifetime (this token) |
+|---|---|---|
+| `access_token` | Bearer token for API calls, `aud: https://api.openai.com/v1` | **10 days** exactly (`exp - iat` = 864000s) |
+| `id_token` | Carries profile + `https://api.openai.com/auth.*` claims (plan type, chatgpt_account_id, org) | **1 hour** (`exp - iat` = 3600s) |
+| `refresh_token` | Opaque `rt.1.…` token | Not JWT-encoded; lifetime unknown from the token itself |
+| `account_id` | UUID, matches the `chatgpt_account_id` claim | n/a |
+
+Refresh flow (confirmed from `~/.codex/log/codex-login.log`, which only ever
+recorded the login/refresh host, not token contents):
+
+```
+POST https://auth.openai.com/oauth/token
+```
+
+This is the single most important structural difference from the app's
+current Anthropic-only assumption: Anthropic's `sk-ant-oat01` tokens are
+long-lived (~1yr), so `Account`/`OAuthPoller` today assume a token is usable
+indefinitely until explicitly revoked. A `provider: openai` account with a
+**10-day access token** requires the poller to actively refresh well before
+every poll cycle assumes staleness — this is a "must design for" item for
+epic phase 2 (the `Account` schema needs a `refresh_token` + `token_expires_at`
+field, not just a bearer string), not an optional nicety.
+
+## What wasn't done, and why
+
+- **No live HTTP call was made** to `chatgpt.com`/`api.openai.com` with the
+  credential on this host, because it is a primary personal account and the
+  issue explicitly disallows that.
+- **No mitmproxy traffic capture** was set up for the same reason — capturing
+  `codex`'s own traffic during normal use would also exercise the primary
+  account's live session.
+- The exact endpoint path, wire JSON field names (vs. the internal Rust
+  field names found here), and per-call cost/quota impact are therefore
+  **unconfirmed**, pending a disposable test account.
+
+## Reproducible next step (for whoever has a disposable ChatGPT Plus/Pro test account)
+
+A ready-to-run, **not yet executed**, probe script is included at
+[`docs/spikes/codex-usage-probe.sh`](codex-usage-probe.sh). It:
+
+1. Reads `access_token` out of `~/.codex/auth.json` (or `$CODEX_HOME/auth.json`)
+   without ever echoing it.
+2. Tries the two most likely candidate requests derived from the static
+   analysis above (`https://chatgpt.com/backend-api/codex/usage` and a
+   `chatgpt-account-id` header variant), printing only the HTTP status code
+   and response body shape (field names / types), not raw token values.
+3. Leaves clear `TODO`s for capturing the *actual* route via mitmproxy
+   (`codex` itself, run once with a proxy env var, against the test account)
+   if the static-analysis guesses miss.
+
+Run it only against a disposable/test account, per the issue's own guidance.
+
+## Recommendation
+
+**Proceed to epic phase 2 (provider abstraction), conditionally.**
+
+The static evidence is strong enough to design the `provider` abstraction
+and `Account` schema now — in particular:
+
+- Model the response as an array of rate-limit windows keyed by
+  `window_minutes` (or a small enum derived from it: `session` / `weekly`),
+  each carrying `used_percent` + `resets_at`, mirroring
+  `RateLimitWindow` — this generalizes cleanly to a shared
+  `RateLimitWindow`-shaped Swift type both providers populate.
+- Extend `Account` (or a provider-specific side table) with
+  `token_expires_at` and treat `refresh_token`-based renewal as mandatory
+  infrastructure for OpenAI accounts, not best-effort — a 10-day access
+  token will expire mid-epic if the poller doesn't refresh proactively.
+- **Before shipping the real OpenAI `OAuthPoller` network path**, add a
+  live-verification checkpoint using a disposable test account to confirm
+  the exact endpoint and wire field names this document could not confirm
+  statically. Do not assume the exact route string in this document is
+  correct without that check — treat it as a strong hypothesis, not a
+  verified contract.
+
+## References
+
+- Codex CLI: `codex-cli 0.146.0`, installed via `brew install --cask codex`
+  at `/opt/homebrew/Caskroom/codex/0.146.0/bin/codex`.
+- `~/.codex/auth.json` — Codex CLI's ChatGPT-OAuth credential store.
+- `~/.codex/log/codex-login.log` — confirms `https://auth.openai.com/oauth/token`
+  as the refresh endpoint.
+- Issue #16 (this repo) — the transcript-leak incident this spike's
+  redaction discipline is following.

--- a/docs/spikes/codex-usage-probe.sh
+++ b/docs/spikes/codex-usage-probe.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Scratch probe for issue #26 (part of the multi-provider epic, #25).
+#
+# NOT YET LIVE-VERIFIED. This script encodes the best hypothesis this spike
+# could derive from static analysis of the Codex CLI binary (see
+# docs/spikes/2026-07-30-codex-usage-probe.md) about how to fetch ChatGPT
+# subscription usage/rate-limit data using a Codex CLI OAuth credential. It
+# has deliberately NOT been run against a live account as part of this spike,
+# because the only credential available at spike time belonged to a primary
+# personal account, and the issue this script was written for explicitly
+# requires a disposable/low-value test account instead.
+#
+# SAFETY:
+#   - Only run this against a disposable/test ChatGPT Plus/Pro account that
+#     you are authorized to probe with. Do NOT run it against a primary
+#     account.
+#   - This script never echoes token values. It reads the access token
+#     directly into a curl Authorization header without passing through any
+#     command that would print it (no `echo $TOKEN`, no `set -x`).
+#   - If you add debug output while iterating, redact tokens and any PII
+#     (email, name, account UUIDs) before sharing output -- including inside
+#     an agent transcript. See the write-up's "Credential situation" section
+#     for the failure mode this guards against.
+#
+# USAGE:
+#   CODEX_HOME="${CODEX_HOME:-$HOME/.codex}" ./codex-usage-probe.sh
+#
+# Requires: curl, jq (for parsing ~/.codex/auth.json and pretty-printing
+# response bodies; falls back to raw output if jq is unavailable).
+
+set -euo pipefail
+
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+AUTH_JSON="$CODEX_HOME/auth.json"
+
+if [[ ! -f "$AUTH_JSON" ]]; then
+  echo "error: no Codex CLI credential at $AUTH_JSON" >&2
+  echo "  Install/log in with a DISPOSABLE test account: 'codex login'" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required to read $AUTH_JSON safely (avoids shell-parsing JSON by hand)" >&2
+  exit 1
+fi
+
+ACCESS_TOKEN="$(jq -r '.tokens.access_token' "$AUTH_JSON")"
+ACCOUNT_ID="$(jq -r '.tokens.account_id' "$AUTH_JSON")"
+
+if [[ -z "$ACCESS_TOKEN" || "$ACCESS_TOKEN" == "null" ]]; then
+  echo "error: could not read tokens.access_token from $AUTH_JSON" >&2
+  exit 1
+fi
+
+echo "== Candidate 1: https://chatgpt.com/backend-api/codex/usage (chatgpt-account-id header) =="
+HTTP_STATUS=$(curl -sS -o /tmp/codex-usage-probe-1.json -w '%{http_code}' \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "chatgpt-account-id: $ACCOUNT_ID" \
+  -H 'Content-Type: application/json' \
+  "https://chatgpt.com/backend-api/codex/usage" || echo "CURL_FAILED")
+echo "status: $HTTP_STATUS"
+if command -v jq >/dev/null 2>&1 && [[ -s /tmp/codex-usage-probe-1.json ]]; then
+  echo "response field names (values redacted):"
+  jq 'walk(if type == "number" or type == "string" then "<redacted>" else . end)' \
+    /tmp/codex-usage-probe-1.json 2>/dev/null || cat /tmp/codex-usage-probe-1.json
+fi
+echo
+
+echo "== Candidate 2: https://chatgpt.com/backend-api/wham/usage (no account-id header) =="
+HTTP_STATUS=$(curl -sS -o /tmp/codex-usage-probe-2.json -w '%{http_code}' \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H 'Content-Type: application/json' \
+  "https://chatgpt.com/backend-api/wham/usage" || echo "CURL_FAILED")
+echo "status: $HTTP_STATUS"
+if command -v jq >/dev/null 2>&1 && [[ -s /tmp/codex-usage-probe-2.json ]]; then
+  echo "response field names (values redacted):"
+  jq 'walk(if type == "number" or type == "string" then "<redacted>" else . end)' \
+    /tmp/codex-usage-probe-2.json 2>/dev/null || cat /tmp/codex-usage-probe-2.json
+fi
+echo
+
+cat <<'EOF'
+If both candidates 404/401: the real route wasn't guessed correctly from
+static analysis alone. Next step is a traffic capture of Codex CLI's own
+`/usage` command against the SAME disposable test account, e.g.:
+
+  mitmproxy -p 8080 &
+  HTTPS_PROXY=http://127.0.0.1:8080 SSL_CERT_FILE=<mitmproxy-ca.pem> codex
+  # inside the TUI: run /usage, then inspect the mitmproxy flow for the
+  # exact request path, headers, and response body field names.
+
+Once the real route + fields are confirmed, update
+docs/spikes/2026-07-30-codex-usage-probe.md and this script accordingly
+before epic phase 2 implements the production OpenAI OAuthPoller path.
+EOF
+
+rm -f /tmp/codex-usage-probe-1.json /tmp/codex-usage-probe-2.json


### PR DESCRIPTION
## Summary

Spike write-up for issue #26 (part of the multi-provider epic, #25): can a
cheap authenticated probe read ChatGPT/Codex subscription usage + rate-limit
windows, the way `AnthropicAPI`'s ping reads `anthropic-ratelimit-unified-*`
headers today?

**No live network probe was made.** `~/.codex/auth.json` exists on the build
host, but decoding its JWT claims (redacted before recording anywhere) showed
it belongs to the operator's **primary personal ChatGPT Pro account** — which
the issue explicitly says not to use ("use a low-value/test account, NOT a
primary account"). Rather than violate that instruction, this spike used
**static analysis of the installed Codex CLI binary** (`strings` over the
Mach-O, which needs no network access or credentials) to recover the
internal response shape, candidate endpoint routes, and auth/token mechanics
Codex CLI itself relies on for its `/usage` display.

## Changes

- `docs/spikes/2026-07-30-codex-usage-probe.md` — full write-up: response
  shape (`RateLimitWindow { used_percent, window_minutes, resets_at }`),
  candidate endpoint routes (`https://chatgpt.com/backend-api/codex/usage`
  and a `/wham/...` alternate), OAuth token lifetime findings (10-day access
  token vs. Anthropic's ~1yr `sk-ant-oat01`, refreshed via
  `https://auth.openai.com/oauth/token`), why no live call was made, and a
  recommendation.
- `docs/spikes/codex-usage-probe.sh` — a ready-to-run, **not yet executed**
  probe script for whoever provisions a disposable test ChatGPT account, with
  explicit safety notes (never echoes token values, redacts response bodies)
  and a documented mitmproxy fallback if the static-analysis route guesses
  are wrong.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| A documented, reproducible probe that returns session/weekly usage, or a clear write-up of why it isn't feasible | ✅ | `docs/spikes/2026-07-30-codex-usage-probe.md` gives the reproducible static-analysis method (`strings` on the Codex CLI binary — anyone with Codex CLI installed can redo it) plus a ready probe script; explains why a *live* call wasn't made (only available credential is a disqualified primary account) |
| Notes on token lifetime/refresh requirements vs. the app's current long-lived-token assumption | ✅ | "Auth mechanics" section: access token = 10 days (vs. Anthropic's ~1yr), id_token = 1 hour, refresh endpoint `https://auth.openai.com/oauth/token`; flagged as a mandatory (not optional) design input for the `Account` schema in epic phase 2 |
| Recommendation: proceed to epic phase 2, or stop | ✅ | "Recommendation" section: conditional proceed — design the provider abstraction against the `RateLimitWindow` shape now, but gate shipping the production OpenAI network path on a live-verification checkpoint with a disposable test account |

## Test Plan

- `bash -n docs/spikes/codex-usage-probe.sh` — script syntax verified.
- Static-analysis findings independently cross-checked across three separate
  `strings` passes (rate-limit type names, route strings, host constants) for
  internal consistency.
- Docs-only change; no app code touched, so no Swift build was required.

Part of #25 (multi-provider epic — stays open)

Closes #26