### PR TITLE
feat: provider-agnostic rate-limit model + provider column on accounts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,11 @@ jobs:
           cd menubar-app/ClaudeMonitor
           swift build
 
+      - name: Self-test (portable core)
+        run: |
+          cd menubar-app/ClaudeMonitor
+          .build/debug/ClaudeMonitor selftest
+
   build-linux:
     runs-on: ubuntu-latest
     container: swift:6.1
@@ -30,6 +35,11 @@ jobs:
         run: |
           cd menubar-app/ClaudeMonitor
           swift build
+
+      - name: Self-test (portable core)
+        run: |
+          cd menubar-app/ClaudeMonitor
+          .build/debug/ClaudeMonitor selftest
 
       - name: Smoke run (no credentials)
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@
 
 - The same package builds on Linux (`swift build` with `libsqlite3-dev` installed) as a headless daemon for Loom hosts — no UI, same poll loop, same `usage.db`/`ranking.json` outputs. See README "Headless Mode / Linux".
 - UI sources are fenced with `#if os(macOS)`; portable core must stay free of AppKit/SwiftUI/Combine/os.Logger. On Linux, `LinuxCompat.swift` shims `ObservableObject`/`@Published`, and `CSQLite/` maps the system libsqlite3 (macOS uses the SDK's `SQLite3` module).
-- Entry points: `main.swift` (macOS, dispatches to `HeadlessRunner` on `--headless`) and `HeadlessMain.swift` (Linux, always headless). Flags: `--once`, `--interval <sec>`, `--version`.
+- Entry points: `main.swift` (macOS, dispatches to `HeadlessRunner` on `--headless`) and `HeadlessMain.swift` (Linux, always headless). Flags: `--once`, `--interval <sec>`, `--version`. Subcommands: `accounts`, `selftest`.
+- Run the test suite with `swift build && .build/debug/ClaudeMonitor selftest` (exits non-zero on failure). CI runs it on macOS and Linux.
+- To verify a schema migration against real data, copy the live DB first — `cp ~/.claude-monitor/usage.db /tmp/ && .build/debug/ClaudeMonitor selftest --db /tmp/usage.db`. `--db` **writes** to the path it is given; never point it at `~/.claude-monitor/usage.db`.
 - Parse response headers via `extractAnthropicHeaders` (lowercased map), never `allHeaderFields` subscripts — those are case-sensitive on Linux.
 - Verify Linux builds from macOS with the `swift:6.1` Docker image (`apt-get install libsqlite3-dev`, then `swift build`).
 
@@ -29,8 +31,11 @@
   - `Sources/HeadlessMain.swift` / `Sources/HeadlessRunner.swift` - Linux entry point + UI-less poll loop (also `--headless` on macOS)
   - `Sources/LinuxCompat.swift` - `ObservableObject`/`@Published` stand-ins for Linux (no Combine)
   - `CSQLite/` - System-library target mapping Linux libsqlite3
-  - `Sources/AnthropicAPI.swift` - API client (usage, profile, token refresh)
+  - `Sources/RateLimitWindow.swift` - Provider-agnostic rate-limit model (`AccountProvider`, `RateLimitWindow`, `RateLimitSnapshot`). Window kind is **derived from the window's duration**, never its position in the provider response, and every window is optional — an account may legitimately report no session window.
+  - `Sources/UsageProviderClient.swift` - `UsageProviderClient` protocol + `ProviderCredentials` / `ProviderUsageSnapshot` / `ProviderAPIError` (aliased as `AnthropicAPIError`)
+  - `Sources/AnthropicAPI.swift` - API client (usage, profile, token refresh); conforms to `UsageProviderClient`
   - `Sources/OAuthPoller.swift` - Ping-based usage polling, token add/import, Fable probes
+  - `Sources/SelfTest.swift` - `ClaudeMonitor selftest`: portable-core assertions (window model, schema migration) with no network/credentials. Run in CI on both macOS and Linux; there is no XCTest target because the package has zero dependencies.
   - `Sources/UsagePopoverView.swift` - Summary-table popover, sortable headers, add-account dialog
   - `Sources/UsageChartView.swift` - Per-account usage-history chart window
   - `Sources/RollTokenView.swift` / `Sources/TokenRoller.swift` - Roll Token wizard + revoke-script generator. The workflow depends on undocumented, web-session-cookie-authenticated `claude.ai/api/oauth` endpoints; if they change, `TokenRoller.revokeAllScript` is the single place to update (see README "Rolling a Token").

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ import — see [Multiple Accounts](#multiple-accounts)), then:
 claude-monitor                  # poll loop, logs to stdout + ~/.claude-monitor/debug.log
 claude-monitor --once           # one poll cycle, write ranking.json, exit
 claude-monitor --interval 300   # override per-account poll interval (seconds, min 60)
+claude-monitor selftest         # self-check (no network/credentials); non-zero exit on failure
 ```
 
 Edits to `accounts.env` / `accounts.local.env` are picked up automatically

--- a/menubar-app/ClaudeMonitor/Sources/AccountSync.swift
+++ b/menubar-app/ClaudeMonitor/Sources/AccountSync.swift
@@ -15,12 +15,17 @@ import Foundation
 enum AccountSync {
     static let formatVersion = 1
 
+    /// New optional fields (`provider`, `tokenExpiresAt`) decode as nil from a
+    /// pre-multi-provider bundle and resolve to Anthropic on import, so
+    /// `formatVersion` stays at 1 — old and new hosts still interoperate.
     struct ExportedCredential: Codable {
         var label: String
         var source: String
+        var provider: String?
         var accessToken: String?
         var refreshToken: String?
         var expiresAt: Int64?
+        var tokenExpiresAt: String?
         var scopes: String?
         var subscriptionType: String?
         var rateLimitTier: String?
@@ -32,6 +37,7 @@ enum AccountSync {
 
     struct ExportedAccount: Codable {
         var id: String
+        var provider: String?
         var accountName: String?
         var email: String?
         var plan: String?
@@ -78,16 +84,27 @@ enum AccountSync {
             let db = try openDatabase(dbPath, readonly: true)
             var accounts: [ExportedAccount] = []
 
-            let acctStmt = try db.prepare(
-                "SELECT id, account_name, email, plan, last_updated, sort_order FROM accounts ORDER BY sort_order, id"
-            )
+            // Provider columns are selected only when present, so exporting
+            // from a database that predates the migration still works.
+            let hasAcctProvider = tableColumns(db, "accounts").contains("provider")
+            let credColumns = tableColumns(db, "oauth_credentials")
+            let hasCredProvider = credColumns.contains("provider")
+            let hasTokenExpiry = credColumns.contains("token_expires_at")
+
+            let acctStmt = try db.prepare("""
+                SELECT id, account_name, email, plan, last_updated, sort_order,
+                       \(hasAcctProvider ? "provider" : "NULL")
+                FROM accounts ORDER BY sort_order, id
+            """)
             for row in acctStmt {
                 guard let id = row[0] as? String else { continue }
 
                 let credStmt = try db.prepare("""
                     SELECT label, source, access_token, refresh_token, expires_at,
                            scopes, subscription_type, rate_limit_tier, is_active,
-                           created_at, updated_at, token_rolled_at
+                           created_at, updated_at, token_rolled_at,
+                           \(hasCredProvider ? "provider" : "NULL"),
+                           \(hasTokenExpiry ? "token_expires_at" : "NULL")
                     FROM oauth_credentials WHERE account_id = ?
                 """)
                 var credentials: [ExportedCredential] = []
@@ -95,9 +112,11 @@ enum AccountSync {
                     credentials.append(ExportedCredential(
                         label: (c[0] as? String) ?? id,
                         source: (c[1] as? String) ?? "token",
+                        provider: AccountProvider(stored: c[12] as? String).rawValue,
                         accessToken: c[2] as? String,
                         refreshToken: c[3] as? String,
                         expiresAt: c[4] as? Int64,
+                        tokenExpiresAt: c[13] as? String,
                         scopes: c[5] as? String,
                         subscriptionType: c[6] as? String,
                         rateLimitTier: c[7] as? String,
@@ -110,6 +129,7 @@ enum AccountSync {
 
                 accounts.append(ExportedAccount(
                     id: id,
+                    provider: AccountProvider(stored: row[6] as? String).rawValue,
                     accountName: row[1] as? String,
                     email: row[2] as? String,
                     plan: row[3] as? String,
@@ -170,6 +190,10 @@ enum AccountSync {
         guard FileManager.default.fileExists(atPath: dbPath) else { throw SyncError.databaseMissing }
         do {
             let db = try openDatabase(dbPath)
+            // Bring the target database up to the current schema first — a host
+            // that has never launched the app still has a pre-migration
+            // database, and the upserts below write the provider columns.
+            try? UsageStore.applySchema(db)
             var summary = ImportSummary()
             for account in bundle.accounts {
                 summary.outcomes.append(try importAccount(account, db: db))
@@ -211,15 +235,20 @@ enum AccountSync {
         let now = ISO8601DateFormatter().string(from: Date())
         let lastUpdated = account.lastUpdated ?? now
 
+        // A bundle exported before multi-provider support carries no provider;
+        // it resolves to Anthropic, which is what those hosts were polling.
+        let provider = AccountProvider(stored: account.provider).rawValue
+
         try db.run("""
-            INSERT INTO accounts (id, account_name, email, plan, last_updated, sort_order)
-            VALUES (?, ?, ?, ?, ?, COALESCE((SELECT MAX(sort_order) + 1 FROM accounts), 0))
+            INSERT INTO accounts (id, account_name, email, plan, last_updated, sort_order, provider)
+            VALUES (?, ?, ?, ?, ?, COALESCE((SELECT MAX(sort_order) + 1 FROM accounts), 0), ?)
             ON CONFLICT(id) DO UPDATE SET
                 account_name = COALESCE(excluded.account_name, accounts.account_name),
                 email = COALESCE(excluded.email, accounts.email),
                 plan = COALESCE(excluded.plan, accounts.plan),
-                last_updated = excluded.last_updated
-        """, targetId, account.accountName, account.email, account.plan, lastUpdated)
+                last_updated = excluded.last_updated,
+                provider = excluded.provider
+        """, targetId, account.accountName, account.email, account.plan, lastUpdated, provider)
 
         for credential in account.credentials {
             try importCredential(credential, accountId: targetId, db: db)
@@ -237,29 +266,35 @@ enum AccountSync {
             "SELECT access_token FROM oauth_credentials WHERE account_id = ? LIMIT 1", accountId
         ) as? String
 
+        let provider = AccountProvider(stored: credential.provider).rawValue
+
         if let credId = existingId {
             // Only bump token_rolled_at when the token value actually changes,
             // mirroring saveCredentialForAccount's roll-clock semantics.
             let tokenChanged = existingToken != credential.accessToken
             try db.run("""
                 UPDATE oauth_credentials SET
-                    label = ?, source = ?, access_token = ?, refresh_token = ?,
-                    expires_at = ?, scopes = ?, subscription_type = ?, rate_limit_tier = ?,
+                    label = ?, source = ?, provider = ?, access_token = ?, refresh_token = ?,
+                    expires_at = ?, token_expires_at = ?,
+                    scopes = ?, subscription_type = ?, rate_limit_tier = ?,
                     is_active = ?, updated_at = ?,
                     token_rolled_at = CASE WHEN ? THEN ? ELSE token_rolled_at END
                 WHERE id = ?
-            """, credential.label, credential.source, credential.accessToken, credential.refreshToken,
-                 credential.expiresAt, credential.scopes, credential.subscriptionType, credential.rateLimitTier,
+            """, credential.label, credential.source, provider, credential.accessToken, credential.refreshToken,
+                 credential.expiresAt, credential.tokenExpiresAt,
+                 credential.scopes, credential.subscriptionType, credential.rateLimitTier,
                  credential.isActive, now, tokenChanged, credential.tokenRolledAt ?? now, credId)
         } else {
             try db.run("""
                 INSERT INTO oauth_credentials (
-                    account_id, label, source, access_token, refresh_token,
-                    expires_at, scopes, subscription_type, rate_limit_tier,
+                    account_id, label, source, provider, access_token, refresh_token,
+                    expires_at, token_expires_at, scopes, subscription_type, rate_limit_tier,
                     is_active, created_at, updated_at, token_rolled_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, accountId, credential.label, credential.source, credential.accessToken, credential.refreshToken,
-                 credential.expiresAt, credential.scopes, credential.subscriptionType, credential.rateLimitTier,
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, accountId, credential.label, credential.source, provider,
+                 credential.accessToken, credential.refreshToken,
+                 credential.expiresAt, credential.tokenExpiresAt,
+                 credential.scopes, credential.subscriptionType, credential.rateLimitTier,
                  credential.isActive, credential.createdAt ?? now, now, credential.tokenRolledAt)
         }
     }

--- a/menubar-app/ClaudeMonitor/Sources/AnthropicAPI.swift
+++ b/menubar-app/ClaudeMonitor/Sources/AnthropicAPI.swift
@@ -47,40 +47,42 @@ struct PingResponse {
     var weeklyResetISO: String? {
         weeklyReset.map { ISO8601DateFormatter().string(from: $0) }
     }
+
+    /// This ping expressed in the shared, provider-agnostic window model.
+    ///
+    /// A window is present only when the corresponding header family actually
+    /// came back — an absent `-5h-utilization` header yields `session == nil`
+    /// rather than a fabricated 0%, which is the same "no session window"
+    /// state OpenAI accounts can legitimately be in.
+    var rateLimit: RateLimitSnapshot {
+        RateLimitSnapshot(
+            session: sessionUtilization.map {
+                RateLimitWindow(
+                    kind: .session,
+                    usedPercent: $0 * 100,
+                    resetAt: sessionReset,
+                    status: sessionStatus
+                )
+            },
+            weekly: weeklyUtilization.map {
+                RateLimitWindow(
+                    kind: .weekly,
+                    usedPercent: $0 * 100,
+                    resetAt: weeklyReset,
+                    status: weeklyStatus
+                )
+            },
+            overallStatus: overallStatus
+        )
+    }
 }
 
 // MARK: - API Errors
 
-enum AnthropicAPIError: Error, LocalizedError {
-    case unauthorized
-    case httpError(Int)
-    case invalidResponse
-    case networkError(Error)
-
-    var errorDescription: String? {
-        switch self {
-        case .unauthorized:
-            return "Unauthorized — token may be expired or revoked"
-        case .httpError(let code):
-            return "HTTP error \(code)"
-        case .invalidResponse:
-            return "Invalid response from API"
-        case .networkError(let error):
-            return "Network error: \(error.localizedDescription)"
-        }
-    }
-
-    var isTransient: Bool {
-        switch self {
-        case .httpError(let code):
-            return (500...599).contains(code)
-        case .networkError:
-            return true
-        case .unauthorized, .invalidResponse:
-            return false
-        }
-    }
-}
+/// Historical name for the shared provider error type. Kept so the many
+/// existing `catch AnthropicAPIError.unauthorized` / `if case
+/// AnthropicAPIError.unauthorized = error` sites keep compiling unchanged.
+typealias AnthropicAPIError = ProviderAPIError
 
 // MARK: - API Client
 
@@ -297,4 +299,37 @@ class AnthropicAPIClient {
         guard let epoch = value.flatMap({ TimeInterval($0) }) else { return nil }
         return Date(timeIntervalSince1970: epoch)
     }
+}
+
+// MARK: - UsageProviderClient conformance
+
+/// Anthropic as one provider among several. This is a pure adaptation layer —
+/// `fetchUsage` is `pingToken` and `identifyAccount` is `identifyToken`, both
+/// re-expressed in the shared types. Behavior for Anthropic accounts is
+/// unchanged; the poll loop still calls `pingToken` directly today.
+extension AnthropicAPIClient: UsageProviderClient {
+    var provider: AccountProvider { .anthropic }
+
+    func fetchUsage(_ credentials: ProviderCredentials) async throws -> ProviderUsageSnapshot {
+        let ping = try await pingToken(accessToken: credentials.accessToken)
+        return ProviderUsageSnapshot(
+            provider: .anthropic,
+            accountKey: ping.organizationId,
+            httpStatus: ping.httpStatus,
+            rateLimit: ping.rateLimit,
+            // Anthropic's rate-limit headers carry no identity beyond the org
+            // id; email/plan come from elsewhere (the account list files).
+            email: nil,
+            plan: nil,
+            rawFields: ping.rawHeaders
+        )
+    }
+
+    func identifyAccount(_ credentials: ProviderCredentials) async throws -> String {
+        try await identifyToken(accessToken: credentials.accessToken)
+    }
+
+    // refreshCredentials: the protocol's default (nil) is correct here —
+    // Anthropic subscription OAuth tokens are long-lived (~1yr) and this app
+    // never refreshes them; a dead token is rolled by the user instead.
 }

--- a/menubar-app/ClaudeMonitor/Sources/HeadlessMain.swift
+++ b/menubar-app/ClaudeMonitor/Sources/HeadlessMain.swift
@@ -9,6 +9,8 @@ enum ClaudeMonitorEntry {
         // the always-on poll loop below.
         if CommandLine.arguments.dropFirst().first == "accounts" {
             AccountSyncCLI.main(Array(CommandLine.arguments.dropFirst(2)))
+        } else if CommandLine.arguments.dropFirst().first == "selftest" {
+            SelfTest.main(Array(CommandLine.arguments.dropFirst(2)))
         } else {
             HeadlessRunner.main()
         }

--- a/menubar-app/ClaudeMonitor/Sources/HeadlessRunner.swift
+++ b/menubar-app/ClaudeMonitor/Sources/HeadlessRunner.swift
@@ -133,5 +133,10 @@ enum HeadlessRunner {
 
         For multi-host sync of account records + credentials, see:
           claude-monitor accounts --help
+
+        Subcommands:
+          accounts            Export/import accounts + credentials
+          selftest            Run portable-core assertions (no network, no
+                              credentials; exits non-zero on failure)
         """
 }

--- a/menubar-app/ClaudeMonitor/Sources/OAuthPoller.swift
+++ b/menubar-app/ClaudeMonitor/Sources/OAuthPoller.swift
@@ -45,14 +45,60 @@ struct CredentialStatus: Identifiable {
 struct OAuthCredential {
     let id: Int64?
     let accountId: String?
+    /// Which upstream this credential authenticates against. Pre-migration rows
+    /// resolve to `.anthropic`.
+    let provider: AccountProvider
     let label: String
     let source: String  // "token" or "env"
     let accessToken: String?
     let refreshToken: String?
-    let expiresAt: Int64?  // epoch ms
+    let expiresAt: Int64?  // epoch ms — vestigial keychain-era column
+    /// When `accessToken` expires, parsed from `oauth_credentials.token_expires_at`.
+    /// nil for Anthropic (long-lived tokens); OpenAI access tokens live ~10 days
+    /// and must be refreshed before this instant (spike #26).
+    let tokenExpiresAt: Date?
     let subscriptionType: String?
     let rateLimitTier: String?
     let isActive: Bool
+
+    init(
+        id: Int64?,
+        accountId: String?,
+        provider: AccountProvider = .anthropic,
+        label: String,
+        source: String,
+        accessToken: String?,
+        refreshToken: String?,
+        expiresAt: Int64?,
+        tokenExpiresAt: Date? = nil,
+        subscriptionType: String?,
+        rateLimitTier: String?,
+        isActive: Bool
+    ) {
+        self.id = id
+        self.accountId = accountId
+        self.provider = provider
+        self.label = label
+        self.source = source
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.expiresAt = expiresAt
+        self.tokenExpiresAt = tokenExpiresAt
+        self.subscriptionType = subscriptionType
+        self.rateLimitTier = rateLimitTier
+        self.isActive = isActive
+    }
+
+    /// This credential in the provider-agnostic shape a `UsageProviderClient`
+    /// consumes. nil when there is no access token to present.
+    var providerCredentials: ProviderCredentials? {
+        guard let accessToken = accessToken else { return nil }
+        return ProviderCredentials(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            expiresAt: tokenExpiresAt
+        )
+    }
 }
 
 struct EnvImportResult {
@@ -286,13 +332,17 @@ class OAuthPoller: ObservableObject {
 
     private func saveCredentialForAccount(
         accountId: String, email: String?, orgName: String?, plan: String,
-        accessToken: String, source: String = "token"
+        accessToken: String, source: String = "token",
+        provider: AccountProvider = .anthropic,
+        refreshToken: String? = nil, tokenExpiresAt: Date? = nil
     ) {
         guard FileManager.default.fileExists(atPath: dbPath) else { return }
         do {
             let db = try openDatabase(dbPath)
             let now = ISO8601DateFormatter().string(from: Date())
             let label = orgName ?? email ?? accountId
+            let providerValue = provider.rawValue
+            let expiryISO = tokenExpiresAt.map { ISO8601DateFormatter().string(from: $0) }
 
             // When the profile/caller-supplied email is unavailable, fall back to
             // the label itself if it's a well-formed address — an account must
@@ -303,13 +353,14 @@ class OAuthPoller: ObservableObject {
 
             // Upsert account — never overwrite account_name (user may have renamed)
             try db.run("""
-                INSERT INTO accounts (id, account_name, email, plan, last_updated, sort_order)
-                VALUES (?, ?, ?, ?, ?, COALESCE((SELECT MAX(sort_order) + 1 FROM accounts), 0))
+                INSERT INTO accounts (id, account_name, email, plan, last_updated, sort_order, provider)
+                VALUES (?, ?, ?, ?, ?, COALESCE((SELECT MAX(sort_order) + 1 FROM accounts), 0), ?)
                 ON CONFLICT(id) DO UPDATE SET
                     email = COALESCE(excluded.email, accounts.email),
                     plan = COALESCE(excluded.plan, accounts.plan),
-                    last_updated = excluded.last_updated
-            """, accountId, label, resolvedEmail, plan, now)
+                    last_updated = excluded.last_updated,
+                    provider = excluded.provider
+            """, accountId, label, resolvedEmail, plan, now, providerValue)
 
             // Look for existing credential for THIS account
             let existingCred = try db.scalar(
@@ -328,26 +379,30 @@ class OAuthPoller: ObservableObject {
                 if tokenChanged {
                     try db.run("""
                         UPDATE oauth_credentials SET
-                            access_token = ?, source = ?,
+                            access_token = ?, source = ?, provider = ?,
+                            refresh_token = COALESCE(?, refresh_token),
+                            token_expires_at = ?,
                             is_active = 1, updated_at = ?, token_rolled_at = ?
                         WHERE id = ?
-                    """, accessToken, source, now, now, credId)
+                    """, accessToken, source, providerValue, refreshToken, expiryISO, now, now, credId)
                     flog.info("Rolled credential for account \(accountId)", category: fcat)
                 } else {
                     try db.run("""
                         UPDATE oauth_credentials SET
-                            source = ?, is_active = 1, updated_at = ?
+                            source = ?, provider = ?, is_active = 1, updated_at = ?
                         WHERE id = ?
-                    """, source, now, credId)
+                    """, source, providerValue, now, credId)
                     flog.info("Updated credential for account \(accountId)", category: fcat)
                 }
             } else {
                 try db.run("""
                     INSERT INTO oauth_credentials (
-                        account_id, label, source,
-                        access_token, is_active, created_at, updated_at, token_rolled_at
-                    ) VALUES (?, ?, ?, ?, 1, ?, ?, ?)
-                """, accountId, label, source, accessToken, now, now, now)
+                        account_id, label, source, provider,
+                        access_token, refresh_token, token_expires_at,
+                        is_active, created_at, updated_at, token_rolled_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+                """, accountId, label, source, providerValue,
+                     accessToken, refreshToken, expiryISO, now, now, now)
                 flog.info("Created new credential for account \(accountId)", category: fcat)
             }
         } catch {
@@ -363,10 +418,18 @@ class OAuthPoller: ObservableObject {
             let db = try openDatabase(dbPath, readonly: true)
             var credentials: [OAuthCredential] = []
 
+            // The provider columns are selected only when present, so a
+            // database opened before the migration ran still loads (every row
+            // then resolves to the Anthropic fallback).
+            let columns = tableColumns(db, "oauth_credentials")
+            let hasProvider = columns.contains("provider")
+            let hasTokenExpiry = columns.contains("token_expires_at")
             let stmt = try db.prepare("""
                 SELECT id, account_id, label, source,
                        access_token, refresh_token, expires_at,
-                       subscription_type, rate_limit_tier, is_active
+                       subscription_type, rate_limit_tier, is_active,
+                       \(hasProvider ? "provider" : "NULL"),
+                       \(hasTokenExpiry ? "token_expires_at" : "NULL")
                 FROM oauth_credentials
                 WHERE is_active = 1 AND access_token IS NOT NULL
             """)
@@ -375,11 +438,13 @@ class OAuthPoller: ObservableObject {
                 credentials.append(OAuthCredential(
                     id: row[0] as? Int64,
                     accountId: row[1] as? String,
+                    provider: AccountProvider(stored: row[10] as? String),
                     label: (row[2] as? String) ?? "Unknown",
                     source: (row[3] as? String) ?? "token",
                     accessToken: row[4] as? String,
                     refreshToken: row[5] as? String,
                     expiresAt: row[6] as? Int64,
+                    tokenExpiresAt: UsageRecord.parseISO(row[11] as? String),
                     subscriptionType: row[7] as? String,
                     rateLimitTier: row[8] as? String,
                     isActive: (row[9] as? Int64 ?? 1) == 1
@@ -594,12 +659,19 @@ class OAuthPoller: ObservableObject {
             let db = try openDatabase(dbPath)
             let now = ISO8601DateFormatter().string(from: Date())
 
-            let sessionPercent = ping.sessionPercent
-            let weeklyAllPercent = ping.weeklyPercent
+            // Read through the shared, provider-agnostic window model rather
+            // than the Anthropic-specific header fields. `?? 0` preserves the
+            // long-standing Anthropic behavior of storing 0 for an absent
+            // header; a provider-agnostic writer for genuinely window-less
+            // accounts (OpenAI with no session window) arrives with the phase-3
+            // poller, and the columns are already nullable for it.
+            let windows = ping.rateLimit
+            let sessionPercent = windows.session?.usedPercent ?? 0
+            let weeklyAllPercent = windows.weekly?.usedPercent ?? 0
             let primaryPercent = max(sessionPercent, weeklyAllPercent)
 
-            let sessionReset = ping.sessionResetISO
-            let weeklyReset = ping.weeklyResetISO
+            let sessionReset = windows.session?.resetAtISO
+            let weeklyReset = windows.weekly?.resetAtISO
 
             // Reset detection: check previous reading
             let prevStmt = try db.prepare(

--- a/menubar-app/ClaudeMonitor/Sources/RateLimitWindow.swift
+++ b/menubar-app/ClaudeMonitor/Sources/RateLimitWindow.swift
@@ -1,0 +1,253 @@
+import Foundation
+
+/// Provider-agnostic rate-limit model shared by every upstream this app polls.
+///
+/// Anthropic and OpenAI report the *same* information in different shapes:
+///
+/// | | Anthropic | OpenAI / Codex |
+/// |---|---|---|
+/// | transport | `anthropic-ratelimit-unified-{5h,7d}-*` response headers | `GET /backend-api/wham/usage` JSON body |
+/// | windows | one header family per window, named `5h` / `7d` | `rate_limit.primary_window` / `.secondary_window` |
+/// | usage figure | `-utilization` (0.0–1.0) | `used_percent` (0–100) |
+/// | window length | implied by the header name | `limit_window_seconds` |
+/// | reset | `-reset` (unix epoch seconds) | `reset_at` (unix epoch seconds) |
+///
+/// The types below are the common denominator. See
+/// `docs/spikes/2026-07-30-codex-usage-probe.md` § "Live verification
+/// (AUTHORITATIVE)" for the verified OpenAI wire contract this models.
+///
+/// Portable core: no AppKit / SwiftUI / Combine / os.Logger — builds on Linux.
+
+// MARK: - Provider identity
+
+/// Which upstream an account belongs to.
+enum AccountProvider: String, CaseIterable, Codable {
+    case anthropic
+    case openai
+
+    /// Every account that predates multi-provider support is Anthropic, so an
+    /// absent or unrecognized value resolves here rather than failing.
+    static let fallback: AccountProvider = .anthropic
+
+    /// Tolerant parse of a stored/serialized provider value. Unknown values
+    /// (a row written by a newer build) and missing values (a row written
+    /// before the `provider` column existed) both fall back to `.anthropic`,
+    /// so a strange value can never take the poll loop down.
+    init(stored: String?) {
+        guard let raw = stored?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !raw.isEmpty,
+              let parsed = AccountProvider(rawValue: raw) else {
+            self = AccountProvider.fallback
+            return
+        }
+        self = parsed
+    }
+
+    var displayName: String {
+        switch self {
+        case .anthropic: return "Anthropic"
+        case .openai: return "OpenAI"
+        }
+    }
+}
+
+// MARK: - Window kind
+
+/// Which quota bucket a window represents. **Always derived from the window's
+/// duration, never from its position in the provider's response**: the
+/// live-verified Codex probe returned a *weekly* `primary_window` with
+/// `secondary_window: null`, so "primary = session" is wrong.
+enum RateLimitWindowKind: Equatable {
+    /// The short rolling window (Anthropic's 5h bucket, Codex's session bucket).
+    case session
+    /// The long rolling window (both providers use 7 days).
+    case weekly
+    /// A window whose length matches neither bucket; the payload is its length.
+    case other(TimeInterval)
+    /// The provider gave a usage figure but no window length.
+    case unknown
+
+    /// Nominal length of this bucket in seconds, used when a source is
+    /// kind-labelled but carries no explicit duration (e.g. Anthropic's
+    /// `5h`/`7d` header families, or this app's kind-keyed `usage_history`
+    /// columns).
+    var nominalDuration: TimeInterval? {
+        switch self {
+        case .session: return 5 * 3600
+        case .weekly: return 7 * 86400
+        case .other(let seconds): return seconds
+        case .unknown: return nil
+        }
+    }
+
+    /// Short key used in serialized output (`ranking.json`, logs).
+    var key: String {
+        switch self {
+        case .session: return "5h"
+        case .weekly: return "7d"
+        case .other(let seconds): return "\(Int(seconds))s"
+        case .unknown: return "unknown"
+        }
+    }
+}
+
+// MARK: - Window
+
+/// One rate-limit window: how much of it is spent, how long it is, and when it
+/// resets. Both providers populate this type.
+struct RateLimitWindow: Equatable {
+    let kind: RateLimitWindowKind
+    /// Percentage of the window consumed, 0–100. Anthropic reports a 0.0–1.0
+    /// utilization fraction (multiply by 100); OpenAI reports `used_percent`
+    /// already on this scale.
+    let usedPercent: Double
+    /// Length of the window in seconds, when the provider states it.
+    let durationSeconds: TimeInterval?
+    /// When the window rolls over, when the provider states it.
+    let resetAt: Date?
+    /// Provider status string for this window (`allowed` / `allowed_warning` /
+    /// `rejected` on Anthropic), if any.
+    let status: String?
+
+    /// Explicit-kind initializer — for sources that already know which bucket a
+    /// figure belongs to (Anthropic's `-5h-` / `-7d-` header families, and this
+    /// app's kind-keyed `usage_history` columns).
+    init(
+        kind: RateLimitWindowKind,
+        usedPercent: Double,
+        durationSeconds: TimeInterval? = nil,
+        resetAt: Date? = nil,
+        status: String? = nil
+    ) {
+        self.kind = kind
+        self.usedPercent = usedPercent
+        self.durationSeconds = durationSeconds ?? kind.nominalDuration
+        self.resetAt = resetAt
+        self.status = status
+    }
+
+    /// Duration-derived initializer — for providers that return an unlabelled
+    /// window alongside its length (OpenAI's `primary_window` /
+    /// `secondary_window`, each carrying `limit_window_seconds`).
+    init(
+        usedPercent: Double,
+        durationSeconds: TimeInterval?,
+        resetAt: Date? = nil,
+        status: String? = nil
+    ) {
+        self.kind = RateLimitWindow.kind(forDuration: durationSeconds)
+        self.usedPercent = usedPercent
+        self.durationSeconds = durationSeconds
+        self.resetAt = resetAt
+        self.status = status
+    }
+
+    /// Windows at or under this length are session windows. Anthropic's is 5h
+    /// and Codex's session bucket is nominally the same; the bound is generous
+    /// so a provider re-tuning its short window still classifies correctly.
+    static let sessionUpperBound: TimeInterval = 6 * 3600
+    /// Windows longer than `sessionUpperBound` and no longer than this are the
+    /// weekly bucket (both providers report 604800s today).
+    static let weeklyUpperBound: TimeInterval = 14 * 86400
+
+    /// Classify a window by its length. This is the single place the
+    /// duration → bucket mapping lives.
+    static func kind(forDuration seconds: TimeInterval?) -> RateLimitWindowKind {
+        guard let seconds = seconds, seconds > 0 else { return .unknown }
+        if seconds <= sessionUpperBound { return .session }
+        if seconds <= weeklyUpperBound { return .weekly }
+        return .other(seconds)
+    }
+
+    /// Capacity left in this window, 0–100.
+    var remainingPercent: Double { max(0, 100 - usedPercent) }
+
+    /// Whether this window is spent — either the provider says so outright or
+    /// the usage figure is at the cap.
+    var isExhausted: Bool { status == "rejected" || usedPercent >= 100 }
+
+    /// Reset instant as an ISO 8601 string, for DB storage.
+    var resetAtISO: String? {
+        resetAt.map { ISO8601DateFormatter().string(from: $0) }
+    }
+}
+
+// MARK: - Snapshot
+
+/// A provider's complete rate-limit picture for one account at one instant.
+///
+/// **Every window is optional.** A missing session window is a first-class,
+/// supported state: the live-verified Codex probe returned no session window at
+/// all. Consumers must render it as "unknown", never as 0% used.
+struct RateLimitSnapshot {
+    /// The short rolling window, or nil when the provider reports none.
+    var session: RateLimitWindow?
+    /// The long rolling window, or nil when the provider reports none.
+    var weekly: RateLimitWindow?
+    /// Named per-model / per-feature sub-limits: OpenAI's
+    /// `additional_rate_limits[]` entries, Anthropic's Fable `7d_oi` bucket.
+    var named: [String: RateLimitWindow]
+    /// Account-wide status string, when the provider gives one.
+    var overallStatus: String?
+
+    init(
+        session: RateLimitWindow? = nil,
+        weekly: RateLimitWindow? = nil,
+        named: [String: RateLimitWindow] = [:],
+        overallStatus: String? = nil
+    ) {
+        self.session = session
+        self.weekly = weekly
+        self.named = named
+        self.overallStatus = overallStatus
+    }
+
+    /// Build from an unordered list of windows, filing each into the bucket its
+    /// **duration** implies. This is the entry point for providers that return
+    /// positional windows (OpenAI): pass
+    /// `[primary_window, secondary_window].compactMap { $0 }` and the weekly
+    /// window lands in `weekly` regardless of which slot carried it.
+    /// When two windows classify the same way the more-used one wins, so a
+    /// duplicate can never understate consumption.
+    init(
+        windows: [RateLimitWindow],
+        named: [String: RateLimitWindow] = [:],
+        overallStatus: String? = nil
+    ) {
+        var session: RateLimitWindow?
+        var weekly: RateLimitWindow?
+        var extras = named
+        for window in windows {
+            switch window.kind {
+            case .session:
+                if session == nil || window.usedPercent > session!.usedPercent { session = window }
+            case .weekly:
+                if weekly == nil || window.usedPercent > weekly!.usedPercent { weekly = window }
+            case .other, .unknown:
+                extras[window.kind.key] = window
+            }
+        }
+        self.init(session: session, weekly: weekly, named: extras, overallStatus: overallStatus)
+    }
+
+    /// True when the provider reported no session and no weekly window — i.e.
+    /// there is nothing to score or display.
+    var isEmpty: Bool { session == nil && weekly == nil }
+
+    /// "Which account should I use" score, 0–100. 100 = nothing used, 0 =
+    /// capped on whichever known window is most consumed.
+    ///
+    /// Returns **nil** when no window is known, so callers show "—" rather than
+    /// a misleading 100 (plenty of capacity) or 0 (exhausted). A snapshot with
+    /// only a weekly window scores off the weekly window alone.
+    var headroomScore: Double? {
+        let used = [session?.usedPercent, weekly?.usedPercent].compactMap { $0 }
+        guard let worst = used.max() else { return nil }
+        return max(0, min(100, 100 - worst))
+    }
+
+    /// The window that resets soonest among those we know about, or nil.
+    var nextReset: Date? {
+        [session?.resetAt, weekly?.resetAt].compactMap { $0 }.min()
+    }
+}

--- a/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
+++ b/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
@@ -1,0 +1,333 @@
+import Foundation
+
+/// `ClaudeMonitor selftest` — assertions over the portable core, runnable on
+/// macOS and Linux with no network, no credentials, and no package
+/// dependencies (this project deliberately has none, so there is no XCTest
+/// target to hang tests off).
+///
+/// Everything here operates on throwaway databases under a temporary
+/// directory; the real `~/.claude-monitor/usage.db` is never opened.
+/// Exits 0 when every check passes, 1 otherwise, so CI can gate on it.
+enum SelfTest {
+    private static var failures: [String] = []
+    private static var checks = 0
+
+    static func main(_ arguments: [String] = []) -> Never {
+        failures = []
+        checks = 0
+
+        if arguments.contains("--help") || arguments.contains("-h") {
+            print("""
+                Usage: ClaudeMonitor selftest [--db <path>]
+
+                Runs assertions over the portable core (rate-limit window model,
+                schema migration). No network access and no credentials needed.
+
+                  --db <path>   Additionally migrate an existing database *copy*
+                                and verify its accounts still load. Point this at
+                                a COPY of ~/.claude-monitor/usage.db — it writes.
+
+                Exits 0 when every check passes, 1 otherwise.
+                """)
+            exit(0)
+        }
+
+        testWindowKindDerivation()
+        testSnapshotFromPositionalWindows()
+        testMissingSessionWindow()
+        testProviderParsing()
+        testSchemaMigrationFromPreMigrationDatabase()
+
+        if let idx = arguments.firstIndex(of: "--db"), idx + 1 < arguments.count {
+            testMigrationOfExistingDatabase(at: arguments[idx + 1])
+        }
+
+        if failures.isEmpty {
+            print("selftest: \(checks) check(s) passed")
+            exit(0)
+        }
+        for failure in failures {
+            FileHandle.standardError.write(Data("selftest FAILED: \(failure)\n".utf8))
+        }
+        FileHandle.standardError.write(Data("selftest: \(failures.count)/\(checks) check(s) failed\n".utf8))
+        exit(1)
+    }
+
+    // MARK: - Assertions
+
+    private static func expect(_ condition: Bool, _ message: @autoclosure () -> String) {
+        checks += 1
+        if !condition { failures.append(message()) }
+    }
+
+    private static func expectEqual<T: Equatable>(_ actual: T, _ expected: T, _ label: String) {
+        checks += 1
+        if actual != expected {
+            failures.append("\(label): expected \(expected), got \(actual)")
+        }
+    }
+
+    // MARK: - Window model
+
+    /// Window kind must come from the window's *duration*, never its position
+    /// in the provider response (spike #26: a weekly `primary_window` with a
+    /// null `secondary_window` is a real, observed reply).
+    private static func testWindowKindDerivation() {
+        expectEqual(RateLimitWindow.kind(forDuration: 18000), .session, "5h → session")
+        expectEqual(RateLimitWindow.kind(forDuration: 300), .session, "300s → session")
+        expectEqual(RateLimitWindow.kind(forDuration: 604800), .weekly, "604800s (7d) → weekly")
+        expectEqual(RateLimitWindow.kind(forDuration: nil), .unknown, "no duration → unknown")
+        expectEqual(RateLimitWindow.kind(forDuration: 0), .unknown, "zero duration → unknown")
+        expectEqual(RateLimitWindow.kind(forDuration: 30 * 86400), .other(30 * 86400), "30d → other")
+
+        // Kind-labelled sources get the bucket's nominal duration for free.
+        let labelled = RateLimitWindow(kind: .weekly, usedPercent: 44)
+        expectEqual(labelled.durationSeconds, 7 * 86400, "weekly nominal duration")
+        expectEqual(labelled.remainingPercent, 56, "remainingPercent")
+        expect(!labelled.isExhausted, "44% weekly is not exhausted")
+        expect(RateLimitWindow(kind: .weekly, usedPercent: 12, status: "rejected").isExhausted,
+               "a rejected window is exhausted regardless of percent")
+    }
+
+    /// The exact shape the live-verified Codex probe returned: a *weekly*
+    /// `primary_window` and a null `secondary_window`. Filing by duration must
+    /// land it in `weekly`, leaving `session` nil.
+    private static func testSnapshotFromPositionalWindows() {
+        let primary = RateLimitWindow(
+            usedPercent: 14,
+            durationSeconds: 604800,
+            resetAt: Date(timeIntervalSince1970: 1785967226)
+        )
+        let snapshot = RateLimitSnapshot(windows: [primary])
+
+        expect(snapshot.session == nil, "primary weekly window must not be filed as session")
+        expectEqual(snapshot.weekly?.usedPercent, 14, "weekly usedPercent")
+        expectEqual(snapshot.weekly?.kind, .weekly, "weekly kind")
+        expectEqual(snapshot.headroomScore, 86, "headroom from a weekly-only snapshot")
+
+        // Order must not matter: a session window arriving in the *secondary*
+        // slot still files as session.
+        let reordered = RateLimitSnapshot(windows: [
+            RateLimitWindow(usedPercent: 90, durationSeconds: 604800),
+            RateLimitWindow(usedPercent: 10, durationSeconds: 18000),
+        ])
+        expectEqual(reordered.session?.usedPercent, 10, "session filed from second slot")
+        expectEqual(reordered.weekly?.usedPercent, 90, "weekly filed from first slot")
+        expectEqual(reordered.headroomScore, 10, "headroom uses the most-consumed window")
+    }
+
+    /// A nil session window must be a supported state end-to-end: no crash, and
+    /// no misleading 0%-used / 100-headroom reading.
+    private static func testMissingSessionWindow() {
+        let weeklyOnly = UsageRecord(
+            id: 1, accountId: "acct", timestamp: Date(),
+            primaryPercent: 14, sessionPercent: nil, weeklyAllPercent: 14,
+            weeklySONnetPercent: nil, sessionReset: nil, weeklyReset: nil
+        )
+        expect(weeklyOnly.rateLimit.session == nil, "NULL session_percent must stay nil, not become 0%")
+        expectEqual(headroomScore(weeklyOnly), 86, "weekly-only account scores off the weekly window")
+
+        // Nothing known at all: score is nil so the UI shows "—" rather than a
+        // confident 100 ("plenty of capacity") or 0 ("exhausted").
+        let empty = UsageRecord(
+            id: 2, accountId: "acct", timestamp: Date(),
+            primaryPercent: nil, sessionPercent: nil, weeklyAllPercent: nil,
+            weeklySONnetPercent: nil, sessionReset: nil, weeklyReset: nil
+        )
+        expect(empty.rateLimit.isEmpty, "a record with no windows is empty")
+        expect(headroomScore(empty) == nil, "no windows → nil headroom, never a number")
+        expect(headroomScore(nil) == nil, "no record → nil headroom")
+        expectEqual(UsageStore.resetSeconds(empty), .greatestFiniteMagnitude, "no window → unknown reset")
+
+        // Anthropic's usual both-windows reading is unaffected.
+        let both = UsageRecord(
+            id: 3, accountId: "acct", timestamp: Date(),
+            primaryPercent: 70, sessionPercent: 70, weeklyAllPercent: 30,
+            weeklySONnetPercent: nil, sessionReset: nil, weeklyReset: nil
+        )
+        expectEqual(headroomScore(both), 30, "both windows → scored on the worse one")
+    }
+
+    private static func testProviderParsing() {
+        expectEqual(AccountProvider(stored: nil), .anthropic, "missing provider → anthropic")
+        expectEqual(AccountProvider(stored: ""), .anthropic, "blank provider → anthropic")
+        expectEqual(AccountProvider(stored: "  OpenAI "), .openai, "provider parse is trimmed + case-insensitive")
+        expectEqual(AccountProvider(stored: "martian"), .anthropic, "unknown provider → anthropic fallback")
+        expectEqual(AccountProvider(stored: "openai").rawValue, "openai", "round-trips through rawValue")
+    }
+
+    // MARK: - Schema migration
+
+    /// Builds a database with the *pre-#28* schema, populates it the way a real
+    /// installation would, then runs the current migration over it and checks
+    /// that (a) the new columns exist, (b) existing rows were backfilled to
+    /// `anthropic`, and (c) the account still loads and reads normally.
+    private static func testSchemaMigrationFromPreMigrationDatabase() {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("claude-monitor-selftest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let dbPath = dir.appendingPathComponent("usage.db").path
+
+            // --- The v1.17.0 schema, verbatim minus the new columns. ---
+            let legacy = try openDatabase(dbPath)
+            try legacy.execute("""
+                CREATE TABLE accounts (
+                    id TEXT PRIMARY KEY,
+                    account_name TEXT,
+                    email TEXT,
+                    plan TEXT,
+                    last_updated TEXT,
+                    sort_order INTEGER DEFAULT 0
+                );
+                CREATE TABLE usage_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    account_id TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    primary_percent REAL,
+                    session_percent REAL,
+                    weekly_all_percent REAL,
+                    weekly_sonnet_percent REAL,
+                    session_reset TEXT,
+                    weekly_reset TEXT,
+                    raw_data TEXT,
+                    is_synthetic INTEGER DEFAULT 0
+                );
+                CREATE TABLE oauth_credentials (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    account_id TEXT,
+                    label TEXT NOT NULL,
+                    source TEXT DEFAULT 'keychain',
+                    keychain_service TEXT,
+                    keychain_account TEXT,
+                    access_token TEXT,
+                    refresh_token TEXT,
+                    expires_at INTEGER,
+                    scopes TEXT,
+                    subscription_type TEXT,
+                    rate_limit_tier TEXT,
+                    last_poll_at TEXT,
+                    last_error TEXT,
+                    is_active INTEGER DEFAULT 1,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+            """)
+            let now = ISO8601DateFormatter().string(from: Date())
+            // Backdate the reading: `loadFromDatabase` filters on
+            // `timestamp <= <now, with fractional seconds>`, and a row stamped
+            // in the same second sorts *after* that bound as a string.
+            let earlier = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-60))
+            try legacy.run("""
+                INSERT INTO accounts (id, account_name, email, plan, last_updated, sort_order)
+                VALUES ('org-legacy', 'legacy@example.com', 'legacy@example.com', 'Max', ?, 0)
+            """, now)
+            try legacy.run("""
+                INSERT INTO usage_history
+                    (account_id, timestamp, primary_percent, session_percent,
+                     weekly_all_percent, weekly_sonnet_percent, is_synthetic)
+                VALUES ('org-legacy', ?, 40, 40, 12, 0, 0)
+            """, earlier)
+            try legacy.run("""
+                INSERT INTO oauth_credentials (account_id, label, source, access_token, is_active, created_at, updated_at)
+                VALUES ('org-legacy', 'legacy@example.com', 'token', 'sk-ant-oat01-selftest', 1, ?, ?)
+            """, now, now)
+
+            expect(!tableColumns(legacy, "accounts").contains("provider"),
+                   "fixture must start without the provider column")
+
+            // --- What launching the current build does. ---
+            let store = UsageStore(dbPath: dbPath)
+            store.ensureDatabase()
+
+            let db = try openDatabase(dbPath, readonly: true)
+            expect(tableColumns(db, "accounts").contains("provider"),
+                   "migration adds accounts.provider")
+            let credColumns = tableColumns(db, "oauth_credentials")
+            expect(credColumns.contains("provider"), "migration adds oauth_credentials.provider")
+            expect(credColumns.contains("refresh_token"), "migration ensures oauth_credentials.refresh_token")
+            expect(credColumns.contains("token_expires_at"), "migration adds oauth_credentials.token_expires_at")
+            expect(credColumns.contains("token_rolled_at"), "pre-existing token_rolled_at migration still runs")
+
+            expectEqual(try db.scalar("SELECT provider FROM accounts WHERE id = 'org-legacy'") as? String,
+                        "anthropic", "existing account backfilled to anthropic")
+            expectEqual(try db.scalar("SELECT provider FROM oauth_credentials WHERE account_id = 'org-legacy'") as? String,
+                        "anthropic", "existing credential backfilled to anthropic")
+            expect((try db.scalar("SELECT token_expires_at FROM oauth_credentials WHERE account_id = 'org-legacy'")) == nil,
+                   "Anthropic credentials leave token_expires_at null")
+
+            // The pre-migration account keeps working with no user action.
+            store.loadFromDatabase()
+            expectEqual(store.accounts.count, 1, "migrated account still loads")
+            expectEqual(store.accounts.first?.provider, .anthropic, "loaded account resolves to anthropic")
+            expectEqual(headroomScore(store.latestUsage["org-legacy"]), 60, "usage still reads through the window model")
+
+            // Migration is idempotent — a second launch is a no-op, not an error.
+            UsageStore(dbPath: dbPath).ensureDatabase()
+            expectEqual(try db.scalar("SELECT COUNT(*) FROM accounts") as? Int64, 1,
+                        "re-running the migration doesn't duplicate rows")
+
+            // Export/import round-trips the new columns.
+            let bundle = try AccountSync.exportBundle(dbPath: dbPath)
+            expectEqual(bundle.accounts.first?.provider, "anthropic", "export carries provider")
+            let reimportPath = dir.appendingPathComponent("usage-copy.db").path
+            try FileManager.default.copyItem(atPath: dbPath, toPath: reimportPath)
+            _ = try AccountSync.importBundle(bundle, dbPath: reimportPath)
+            let copy = try openDatabase(reimportPath, readonly: true)
+            expectEqual(try copy.scalar("SELECT provider FROM accounts WHERE id = 'org-legacy'") as? String,
+                        "anthropic", "import preserves provider")
+        } catch {
+            checks += 1
+            failures.append("schema migration test threw: \(error)")
+        }
+    }
+
+    /// Migrate a real (copied) database and confirm its accounts still load —
+    /// the "launch against a pre-migration `usage.db`" check, run on demand
+    /// against a copy of a real installation's database rather than a fixture.
+    private static func testMigrationOfExistingDatabase(at path: String) {
+        do {
+            guard FileManager.default.fileExists(atPath: path) else {
+                checks += 1
+                failures.append("--db: no database at \(path)")
+                return
+            }
+
+            let before = UsageStore(dbPath: path)
+            before.loadFromDatabase()
+            let accountsBefore = before.accounts.count
+            let scoresBefore = before.accounts.reduce(into: [String: Double?]()) {
+                $0[$1.id] = headroomScore(before.latestUsage[$1.id])
+            }
+
+            let store = UsageStore(dbPath: path)
+            store.ensureDatabase()
+            store.loadFromDatabase()
+
+            let db = try openDatabase(path, readonly: true)
+            expect(tableColumns(db, "accounts").contains("provider"),
+                   "--db: migration added accounts.provider")
+            let credColumns = tableColumns(db, "oauth_credentials")
+            expect(credColumns.contains("provider"), "--db: migration added oauth_credentials.provider")
+            expect(credColumns.contains("token_expires_at"), "--db: migration added oauth_credentials.token_expires_at")
+
+            expectEqual(store.accounts.count, accountsBefore, "--db: account count unchanged by migration")
+            expect(store.accounts.allSatisfy { $0.provider == .anthropic },
+                   "--db: every pre-existing account backfilled to anthropic")
+            for account in store.accounts {
+                expectEqual(headroomScore(store.latestUsage[account.id]),
+                            scoresBefore[account.id] ?? nil,
+                            "--db: headroom for \(account.id) unchanged by migration")
+            }
+            let stray = try db.scalar(
+                "SELECT COUNT(*) FROM accounts WHERE provider IS NULL OR TRIM(provider) = ''"
+            ) as? Int64
+            expectEqual(stray, 0, "--db: no account left without a provider")
+            print("selftest --db: migrated \(store.accounts.count) account(s) at \(path)")
+        } catch {
+            checks += 1
+            failures.append("--db migration check threw: \(error)")
+        }
+    }
+}

--- a/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
@@ -71,16 +71,9 @@ enum SortDirection {
     func toggled() -> SortDirection { self == .asc ? .desc : .asc }
 }
 
-/// "Which account should I use" score 0–100.
-/// 100 = no usage / max headroom; 0 = capped on either session or weekly.
-/// Returns nil if there's no usage data yet (sorts to bottom).
-func headroomScore(_ usage: UsageRecord?) -> Double? {
-    guard let usage = usage else { return nil }
-    let session = usage.sessionPercent ?? 0
-    let weekly = usage.weeklyAllPercent ?? 0
-    let used = max(session, weekly)
-    return max(0, min(100, 100 - used))
-}
+// `headroomScore` now lives in the portable core (UsageStore.swift) and reads
+// through `UsageRecord.rateLimit`, so the headless Linux daemon scores accounts
+// the same way this popover does.
 
 /// Sort key for the Extra-usage column. Lower = more attention needed.
 /// nil (no probe yet) sorts last.
@@ -96,16 +89,9 @@ func extraUsageUrgency(_ usage: UsageRecord?) -> Double? {
     }
 }
 
-/// Seconds until reset for an ISO-8601 string; nil if unparseable/absent.
-func resetSecondsForString(_ str: String?) -> Double? {
-    guard let str = str else { return nil }
-    let iso = ISO8601DateFormatter()
-    iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    if let date = iso.date(from: str) ?? ISO8601DateFormatter().date(from: str) {
-        return date.timeIntervalSinceNow
-    }
-    return nil
-}
+// Reset-time sorting now reads `RateLimitWindow.resetAt` (already a `Date`) via
+// `UsageRecord.rateLimit`, so the string-parsing helper that used to live here
+// is gone; `UsageRecord.parseISO` is the single ISO-8601 parse point.
 
 /// Lower rank = "better" status (valid first, missing last).
 func tokenStatusRank(_ status: TokenStatus) -> Int {
@@ -197,9 +183,12 @@ struct UsagePopoverView: View {
         case .headroom:
             return (headroomScore(a.1), headroomScore(b.1))
         case .sessionPercent:
-            return (a.1?.sessionPercent, b.1?.sessionPercent)
+            // Read through the shared window model: a provider that reports no
+            // session window yields nil here and sorts last, rather than
+            // pretending to be at 0%.
+            return (a.1?.rateLimit.session?.usedPercent, b.1?.rateLimit.session?.usedPercent)
         case .weeklyPercent:
-            return (a.1?.weeklyAllPercent, b.1?.weeklyAllPercent)
+            return (a.1?.rateLimit.weekly?.usedPercent, b.1?.rateLimit.weekly?.usedPercent)
         case .fablePercent:
             // Sort by Fable used (asc = most remaining last, matching other % columns).
             return (a.1?.fablePercent, b.1?.fablePercent)
@@ -207,9 +196,11 @@ struct UsagePopoverView: View {
             // Ascending = "needs attention first": empty → low balance → in use → ready → off.
             return (extraUsageUrgency(a.1), extraUsageUrgency(b.1))
         case .sessionReset:
-            return (resetSecondsForString(a.1?.sessionReset), resetSecondsForString(b.1?.sessionReset))
+            return (a.1?.rateLimit.session?.resetAt?.timeIntervalSinceNow,
+                    b.1?.rateLimit.session?.resetAt?.timeIntervalSinceNow)
         case .weeklyReset:
-            return (resetSecondsForString(a.1?.weeklyReset), resetSecondsForString(b.1?.weeklyReset))
+            return (a.1?.rateLimit.weekly?.resetAt?.timeIntervalSinceNow,
+                    b.1?.rateLimit.weekly?.resetAt?.timeIntervalSinceNow)
         case .fresh:
             // Data age in seconds (lower = fresher). nil usage → nil → sorts last.
             return (a.1.map { -$0.timestamp.timeIntervalSinceNow },
@@ -681,19 +672,22 @@ struct SummaryRow: View {
             headroomCell
                 .frame(width: SummaryColumns.headroom, alignment: .trailing)
 
-            percentText(usage?.sessionPercent)
+            // Session and weekly cells both read the shared window model. When a
+            // provider reports no session window at all, `session` is nil and
+            // both cells render "—" rather than a misleading 0% / "now".
+            percentText(usage?.rateLimit.session?.usedPercent)
                 .frame(width: SummaryColumns.percent, alignment: .trailing)
 
-            Text(resetLabel(usage?.sessionReset))
+            Text(resetLabel(usage?.rateLimit.session?.resetAt))
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .lineLimit(1)
                 .frame(width: SummaryColumns.reset, alignment: .trailing)
 
-            percentText(usage?.weeklyAllPercent)
+            percentText(usage?.rateLimit.weekly?.usedPercent)
                 .frame(width: SummaryColumns.percent, alignment: .trailing)
 
-            Text(resetLabel(usage?.weeklyReset))
+            Text(resetLabel(usage?.rateLimit.weekly?.resetAt))
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .lineLimit(1)
@@ -789,17 +783,13 @@ struct SummaryRow: View {
         isEditingName = false
     }
 
-    private func resetLabel(_ str: String?) -> String {
-        guard let str = str else { return "—" }
-        let isoFormatter = ISO8601DateFormatter()
-        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let date = isoFormatter.date(from: str) ?? ISO8601DateFormatter().date(from: str)
-        if let date = date {
-            let interval = date.timeIntervalSinceNow
-            if interval <= 0 { return "now" }
-            return formatInterval(interval)
-        }
-        return str
+    /// "—" when the window is absent or carries no reset instant — the same
+    /// rendering an OpenAI account with no session window gets.
+    private func resetLabel(_ date: Date?) -> String {
+        guard let date = date else { return "—" }
+        let interval = date.timeIntervalSinceNow
+        if interval <= 0 { return "now" }
+        return formatInterval(interval)
     }
 
     @ViewBuilder

--- a/menubar-app/ClaudeMonitor/Sources/UsageProviderClient.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageProviderClient.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+/// The provider-agnostic usage-fetch surface. `AnthropicAPIClient` is the first
+/// conformer; the OpenAI/Codex client (`GET /backend-api/wham/usage`) lands in
+/// epic phase 3 as a second one.
+///
+/// Portable core: no AppKit / SwiftUI / Combine / os.Logger — builds on Linux.
+
+// MARK: - Credentials
+
+/// The credential material one account needs to talk to its provider.
+///
+/// `refreshToken` / `expiresAt` are mandatory infrastructure rather than a
+/// nicety: OpenAI access tokens live ~10 days (verified in spike #26), so a
+/// poller that assumes an indefinitely-valid bearer silently starts failing.
+/// Anthropic's `sk-ant-oat01` tokens carry no expiry, so both stay nil there.
+struct ProviderCredentials {
+    let accessToken: String
+    let refreshToken: String?
+    /// When `accessToken` stops working. nil = unknown, or does not expire.
+    let expiresAt: Date?
+
+    init(accessToken: String, refreshToken: String? = nil, expiresAt: Date? = nil) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.expiresAt = expiresAt
+    }
+
+    /// Whether the access token is at or near expiry and should be renewed
+    /// before the next usage fetch. Credentials with no stated expiry
+    /// (Anthropic) never report as expiring.
+    func isExpiring(within lead: TimeInterval = 3600, now: Date = Date()) -> Bool {
+        guard let expiresAt = expiresAt else { return false }
+        return expiresAt.timeIntervalSince(now) <= lead
+    }
+
+    /// Whether a renewal is even possible for this credential.
+    var isRefreshable: Bool {
+        guard let refreshToken = refreshToken else { return false }
+        return !refreshToken.isEmpty
+    }
+}
+
+// MARK: - Usage snapshot
+
+/// One provider-agnostic usage reading for one account.
+struct ProviderUsageSnapshot {
+    let provider: AccountProvider
+    /// Stable per-provider account key — Anthropic's organization id, OpenAI's
+    /// `account_id`. This is what the `accounts.id` column holds.
+    let accountKey: String
+    let httpStatus: Int
+    let rateLimit: RateLimitSnapshot
+    /// Identity the provider volunteered alongside usage. OpenAI's usage
+    /// response carries `email` / `plan_type`; Anthropic's headers carry
+    /// neither, so both are nil there.
+    let email: String?
+    let plan: String?
+    /// Verbatim wire fields (Anthropic: every `anthropic-*` response header;
+    /// OpenAI: the flattened JSON body). Archived per poll so fields the
+    /// provider adds are captured even before we interpret them.
+    let rawFields: [String: String]
+
+    init(
+        provider: AccountProvider,
+        accountKey: String,
+        httpStatus: Int,
+        rateLimit: RateLimitSnapshot,
+        email: String? = nil,
+        plan: String? = nil,
+        rawFields: [String: String] = [:]
+    ) {
+        self.provider = provider
+        self.accountKey = accountKey
+        self.httpStatus = httpStatus
+        self.rateLimit = rateLimit
+        self.email = email
+        self.plan = plan
+        self.rawFields = rawFields
+    }
+}
+
+// MARK: - Errors
+
+/// Errors any provider client can raise. Historically named
+/// `AnthropicAPIError`; that name survives as a typealias (see
+/// `AnthropicAPI.swift`) so existing `catch AnthropicAPIError.unauthorized`
+/// sites keep working unchanged.
+///
+/// Not `Equatable` — match with `if case .unauthorized = error`.
+enum ProviderAPIError: Error, LocalizedError {
+    case unauthorized
+    case httpError(Int)
+    case invalidResponse
+    case networkError(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .unauthorized:
+            return "Unauthorized — token may be expired or revoked"
+        case .httpError(let code):
+            return "HTTP error \(code)"
+        case .invalidResponse:
+            return "Invalid response from API"
+        case .networkError(let error):
+            return "Network error: \(error.localizedDescription)"
+        }
+    }
+
+    var isTransient: Bool {
+        switch self {
+        case .httpError(let code):
+            return (500...599).contains(code)
+        case .networkError:
+            return true
+        case .unauthorized, .invalidResponse:
+            return false
+        }
+    }
+}
+
+// MARK: - Protocol
+
+/// A client that can read one provider's subscription usage.
+protocol UsageProviderClient: AnyObject {
+    /// Which provider this client speaks to.
+    var provider: AccountProvider { get }
+
+    /// Fetch the current rate-limit state for a credential.
+    func fetchUsage(_ credentials: ProviderCredentials) async throws -> ProviderUsageSnapshot
+
+    /// Determine which account a credential belongs to, ideally without
+    /// consuming quota. Returns the provider's stable account key.
+    func identifyAccount(_ credentials: ProviderCredentials) async throws -> String
+
+    /// Renew an access token that is at or near expiry. Returns nil for
+    /// providers whose tokens don't expire — callers keep using the current
+    /// credential rather than treating nil as a failure.
+    func refreshCredentials(_ credentials: ProviderCredentials) async throws -> ProviderCredentials?
+}
+
+extension UsageProviderClient {
+    /// Default: nothing to refresh. Providers with expiring tokens override.
+    func refreshCredentials(_ credentials: ProviderCredentials) async throws -> ProviderCredentials? {
+        nil
+    }
+}

--- a/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
@@ -11,13 +11,46 @@ func openDatabase(_ path: String, readonly: Bool = false) throws -> Connection {
     return db
 }
 
+/// Column names present on `table`, or an empty set when the table doesn't
+/// exist. Lets read paths tolerate a database that hasn't been migrated yet
+/// (e.g. `accounts export` run before the app has launched once).
+func tableColumns(_ db: Connection, _ table: String) -> Set<String> {
+    guard let stmt = try? db.prepare("PRAGMA table_info(\(table))") else { return [] }
+    var names: Set<String> = []
+    for row in stmt {
+        if let name = row[1] as? String { names.insert(name) }
+    }
+    return names
+}
+
 struct Account: Identifiable {
     let id: String
+    /// Which upstream this account belongs to. Rows written before
+    /// multi-provider support resolve to `.anthropic` via the schema migration.
+    let provider: AccountProvider
     let accountName: String?
     let email: String?
     let plan: String?
     let lastUpdated: Date?
     let latestPercent: Double?
+
+    init(
+        id: String,
+        provider: AccountProvider = .anthropic,
+        accountName: String?,
+        email: String?,
+        plan: String?,
+        lastUpdated: Date?,
+        latestPercent: Double?
+    ) {
+        self.id = id
+        self.provider = provider
+        self.accountName = accountName
+        self.email = email
+        self.plan = plan
+        self.lastUpdated = lastUpdated
+        self.latestPercent = latestPercent
+    }
 
     /// Returns the best display name for the account
     var displayName: String {
@@ -55,6 +88,41 @@ struct UsageRecord: Identifiable {
         fablePercent.map { max(0, 100 - $0) }
     }
 
+    /// This stored reading expressed in the shared, provider-agnostic window
+    /// model. The `usage_history` columns are already kind-keyed (a session
+    /// column and a weekly column), so each window's kind is explicit and its
+    /// duration is the bucket's nominal length.
+    ///
+    /// A NULL column stays nil here — it is **not** coerced to 0%. That is what
+    /// makes "this provider reported no session window" survive the round trip
+    /// through the database (an OpenAI account may legitimately have none), and
+    /// what keeps `headroomScore` from reporting full capacity for an account
+    /// we know nothing about.
+    var rateLimit: RateLimitSnapshot {
+        var named: [String: RateLimitWindow] = [:]
+        if let fable = fablePercent {
+            named["fable"] = RateLimitWindow(kind: .weekly, usedPercent: fable)
+        }
+        return RateLimitSnapshot(
+            session: sessionPercent.map {
+                RateLimitWindow(kind: .session, usedPercent: $0, resetAt: UsageRecord.parseISO(sessionReset))
+            },
+            weekly: weeklyAllPercent.map {
+                RateLimitWindow(kind: .weekly, usedPercent: $0, resetAt: UsageRecord.parseISO(weeklyReset))
+            },
+            named: named
+        )
+    }
+
+    /// Parses the two ISO 8601 shapes this codebase writes (with and without
+    /// fractional seconds).
+    static func parseISO(_ string: String?) -> Date? {
+        guard let string = string, !string.isEmpty else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: string) ?? ISO8601DateFormatter().date(from: string)
+    }
+
     /// Compact state of the extra-usage balance for display. `.percent` carries
     /// a remaining figure only when the balance is actually metered (>0 used).
     enum ExtraUsageState {
@@ -77,6 +145,20 @@ struct UsageRecord: Identifiable {
             return .unknown
         }
     }
+}
+
+/// "Which account should I use" score 0–100.
+/// 100 = no usage / max headroom; 0 = capped on any known window.
+///
+/// Returns nil when there is no usage data at all — either no reading yet, or a
+/// reading whose provider reported neither a session nor a weekly window. The
+/// popover renders nil as "—" so an account we know nothing about never
+/// masquerades as fully available.
+///
+/// Lives in the portable core (not the macOS-only popover) because the headless
+/// Linux daemon and `ranking.json` reason about the same score.
+func headroomScore(_ usage: UsageRecord?) -> Double? {
+    usage?.rateLimit.headroomScore
 }
 
 struct UsageDataPoint: Identifiable {
@@ -145,9 +227,12 @@ class UsageStore: ObservableObject {
 
     private let dbPath: String
 
-    init() {
-        let homeDir = FileManager.default.homeDirectoryForCurrentUser
-        dbPath = homeDir.appendingPathComponent(".claude-monitor/usage.db").path
+    /// `dbPath` defaults to `~/.claude-monitor/usage.db`. An explicit path is
+    /// used by the self-test to exercise schema migration against a throwaway
+    /// database without touching the real one.
+    init(dbPath: String? = nil) {
+        self.dbPath = dbPath ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude-monitor/usage.db").path
     }
 
     /// Creates the database and schema if they don't exist.
@@ -161,82 +246,143 @@ class UsageStore: ObservableObject {
         do {
             let db = try openDatabase(dbPath)
             try db.execute("PRAGMA journal_mode=WAL")
-            try db.execute("""
-                CREATE TABLE IF NOT EXISTS accounts (
-                    id TEXT PRIMARY KEY,
-                    account_name TEXT,
-                    email TEXT,
-                    plan TEXT,
-                    last_updated TEXT,
-                    sort_order INTEGER DEFAULT 0
-                );
-                CREATE TABLE IF NOT EXISTS usage_history (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    account_id TEXT NOT NULL,
-                    timestamp TEXT NOT NULL,
-                    primary_percent REAL,
-                    session_percent REAL,
-                    weekly_all_percent REAL,
-                    weekly_sonnet_percent REAL,
-                    session_reset TEXT,
-                    weekly_reset TEXT,
-                    raw_data TEXT,
-                    is_synthetic INTEGER DEFAULT 0,
-                    FOREIGN KEY (account_id) REFERENCES accounts(id)
-                );
-                CREATE TABLE IF NOT EXISTS settings (
-                    key TEXT PRIMARY KEY,
-                    value TEXT
-                );
-                CREATE TABLE IF NOT EXISTS probe_snapshots (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    account_id TEXT NOT NULL,
-                    timestamp TEXT NOT NULL,
-                    probe_model TEXT NOT NULL,
-                    http_status INTEGER,
-                    headers TEXT NOT NULL,
-                    FOREIGN KEY (account_id) REFERENCES accounts(id)
-                );
-                CREATE INDEX IF NOT EXISTS idx_usage_account ON usage_history(account_id);
-                CREATE INDEX IF NOT EXISTS idx_usage_timestamp ON usage_history(timestamp DESC);
-                CREATE INDEX IF NOT EXISTS idx_probe_account_time ON probe_snapshots(account_id, timestamp DESC);
-                CREATE TABLE IF NOT EXISTS oauth_credentials (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    account_id TEXT,
-                    label TEXT NOT NULL,
-                    source TEXT DEFAULT 'keychain',
-                    keychain_service TEXT,
-                    keychain_account TEXT,
-                    access_token TEXT,
-                    refresh_token TEXT,
-                    expires_at INTEGER,
-                    scopes TEXT,
-                    subscription_type TEXT,
-                    rate_limit_tier TEXT,
-                    last_poll_at TEXT,
-                    last_error TEXT,
-                    is_active INTEGER DEFAULT 1,
-                    created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    token_rolled_at TEXT,
-                    FOREIGN KEY (account_id) REFERENCES accounts(id)
-                );
-            """)
-
-            // Migration: add token_rolled_at to older DBs. `updated_at` can't serve
-            // this — it's bumped on every poll — so we track token changes separately.
-            // ADD COLUMN throws if it already exists; that's the expected no-op path.
-            try? db.execute("ALTER TABLE oauth_credentials ADD COLUMN token_rolled_at TEXT")
-
-            // Migration: heal accounts left with email = NULL by earlier app
-            // versions — e.g. added via plain token paste (no email known) and
-            // later renamed to the real address, which only touched
-            // account_name. `email` is the join key downstream consumers (like
-            // loom-daemon's `tokens import-from-monitor`) key accounts on, so an
-            // account must never persist indefinitely without one (#15).
-            backfillMissingEmailsFromAccountName(db)
+            try UsageStore.applySchema(db)
         } catch {
             FileLogger.shared.error("Failed to create database: \(error)", category: "DB")
+        }
+    }
+
+    /// Idempotent schema creation plus healing migrations, against any
+    /// read-write connection. Safe to run on every launch — that is the
+    /// established pattern here (#15, #23): heal in place rather than make the
+    /// user re-add accounts.
+    static func applySchema(_ db: Connection) throws {
+        try db.execute("""
+            CREATE TABLE IF NOT EXISTS accounts (
+                id TEXT PRIMARY KEY,
+                account_name TEXT,
+                email TEXT,
+                plan TEXT,
+                last_updated TEXT,
+                sort_order INTEGER DEFAULT 0,
+                provider TEXT NOT NULL DEFAULT 'anthropic'
+            );
+            CREATE TABLE IF NOT EXISTS usage_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_id TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                primary_percent REAL,
+                session_percent REAL,
+                weekly_all_percent REAL,
+                weekly_sonnet_percent REAL,
+                session_reset TEXT,
+                weekly_reset TEXT,
+                raw_data TEXT,
+                is_synthetic INTEGER DEFAULT 0,
+                FOREIGN KEY (account_id) REFERENCES accounts(id)
+            );
+            CREATE TABLE IF NOT EXISTS settings (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            CREATE TABLE IF NOT EXISTS probe_snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_id TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                probe_model TEXT NOT NULL,
+                http_status INTEGER,
+                headers TEXT NOT NULL,
+                FOREIGN KEY (account_id) REFERENCES accounts(id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_usage_account ON usage_history(account_id);
+            CREATE INDEX IF NOT EXISTS idx_usage_timestamp ON usage_history(timestamp DESC);
+            CREATE INDEX IF NOT EXISTS idx_probe_account_time ON probe_snapshots(account_id, timestamp DESC);
+            CREATE TABLE IF NOT EXISTS oauth_credentials (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_id TEXT,
+                label TEXT NOT NULL,
+                source TEXT DEFAULT 'keychain',
+                keychain_service TEXT,
+                keychain_account TEXT,
+                access_token TEXT,
+                refresh_token TEXT,
+                expires_at INTEGER,
+                scopes TEXT,
+                subscription_type TEXT,
+                rate_limit_tier TEXT,
+                last_poll_at TEXT,
+                last_error TEXT,
+                is_active INTEGER DEFAULT 1,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                token_rolled_at TEXT,
+                provider TEXT NOT NULL DEFAULT 'anthropic',
+                token_expires_at TEXT,
+                FOREIGN KEY (account_id) REFERENCES accounts(id)
+            );
+        """)
+
+        // Migration: add token_rolled_at to older DBs. `updated_at` can't serve
+        // this — it's bumped on every poll — so we track token changes separately.
+        // ADD COLUMN throws if it already exists; that's the expected no-op path.
+        try? db.execute("ALTER TABLE oauth_credentials ADD COLUMN token_rolled_at TEXT")
+
+        // Migration (multi-provider, #28): provider identity + refresh-capable
+        // credentials. SQLite's ADD COLUMN with a constant DEFAULT backfills
+        // every existing row in place, so accounts written before this build
+        // become `provider = 'anthropic'` with no user action.
+        //
+        // The credential columns live on `oauth_credentials` rather than
+        // `accounts` because that is already the table that holds token
+        // material; `accounts` stays free of secrets (RankingExporter reads
+        // it directly and must never see one).
+        addColumnIfMissing(db, table: "accounts",
+                           column: "provider", definition: "TEXT NOT NULL DEFAULT 'anthropic'")
+        addColumnIfMissing(db, table: "oauth_credentials",
+                           column: "provider", definition: "TEXT NOT NULL DEFAULT 'anthropic'")
+        // `refresh_token` has been in the CREATE TABLE since the beginning,
+        // so this is a no-op on every database we have seen — kept so the
+        // migration is self-describing and heals a truncated schema.
+        addColumnIfMissing(db, table: "oauth_credentials",
+                           column: "refresh_token", definition: "TEXT")
+        // ISO 8601 expiry of the access token. Distinct from the vestigial
+        // epoch-ms `expires_at` column (a keychain-import-era field this app
+        // has never written), and consistent with `token_rolled_at`'s format.
+        // Stays NULL for Anthropic; OpenAI access tokens live ~10 days and
+        // must be refreshed before this instant (spike #26).
+        addColumnIfMissing(db, table: "oauth_credentials",
+                           column: "token_expires_at", definition: "TEXT")
+
+        // Heal rows whose provider is absent/blank — a database edited by an
+        // external tool, or one where an earlier ADD COLUMN raced.
+        try? db.run("UPDATE accounts SET provider = ? WHERE provider IS NULL OR TRIM(provider) = ''",
+                    AccountProvider.fallback.rawValue)
+        try? db.run("UPDATE oauth_credentials SET provider = ? WHERE provider IS NULL OR TRIM(provider) = ''",
+                    AccountProvider.fallback.rawValue)
+
+        // Migration: heal accounts left with email = NULL by earlier app
+        // versions — e.g. added via plain token paste (no email known) and
+        // later renamed to the real address, which only touched
+        // account_name. `email` is the join key downstream consumers (like
+        // loom-daemon's `tokens import-from-monitor`) key accounts on, so an
+        // account must never persist indefinitely without one (#15).
+        backfillMissingEmailsFromAccountName(db)
+    }
+
+    /// Adds a column only when it isn't already there. `ALTER TABLE ... ADD
+    /// COLUMN` throws on a duplicate; checking first keeps the (expected)
+    /// already-migrated path free of spurious errors and lets us log the one
+    /// launch where a real migration happens.
+    private static func addColumnIfMissing(
+        _ db: Connection, table: String, column: String, definition: String
+    ) {
+        let existing = tableColumns(db, table)
+        guard !existing.isEmpty, !existing.contains(column) else { return }
+        do {
+            try db.execute("ALTER TABLE \(table) ADD COLUMN \(column) \(definition)")
+            FileLogger.shared.info("Migrated \(table): added \(column)", category: "DB")
+        } catch {
+            FileLogger.shared.error("Migration failed adding \(table).\(column): \(error)", category: "DB")
         }
     }
 
@@ -245,7 +391,7 @@ class UsageStore: ObservableObject {
     /// copied into `email`. Idempotent and side-effect-free once every row is
     /// backfilled — cheap enough to run unconditionally on every launch rather
     /// than tracking a schema version for it.
-    private func backfillMissingEmailsFromAccountName(_ db: Connection) {
+    private static func backfillMissingEmailsFromAccountName(_ db: Connection) {
         do {
             let stmt = try db.prepare("SELECT id, account_name FROM accounts WHERE email IS NULL AND account_name IS NOT NULL")
             var candidates: [(id: String, name: String)] = []
@@ -266,15 +412,13 @@ class UsageStore: ObservableObject {
         }
     }
 
-    /// Seconds until reset (session first, then weekly). Returns large value if unknown.
+    /// Seconds until reset (session first, then weekly). Returns large value if
+    /// unknown — including when the provider reports no window at all.
     static func resetSeconds(_ usage: UsageRecord?) -> TimeInterval {
         guard let usage = usage else { return .greatestFiniteMagnitude }
-        for str in [usage.sessionReset, usage.weeklyReset].compactMap({ $0 }) {
-            let iso = ISO8601DateFormatter()
-            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            if let date = iso.date(from: str) ?? ISO8601DateFormatter().date(from: str) {
-                return date.timeIntervalSinceNow
-            }
+        let snapshot = usage.rateLimit
+        for date in [snapshot.session?.resetAt, snapshot.weekly?.resetAt].compactMap({ $0 }) {
+            return date.timeIntervalSinceNow
         }
         return .greatestFiniteMagnitude
     }
@@ -297,13 +441,21 @@ class UsageStore: ObservableObject {
     }
 
     /// Accounts sorted for popover display: most available (lowest usage) first.
+    /// Reads through the shared window model, so an account whose provider
+    /// reports only a weekly window is ranked on that window alone rather than
+    /// being credited with a fictitious 0% session.
     var sortedAccountsForPopover: [Account] {
         let pairs = accounts.map { account in
             (account: account, usage: latestUsage[account.id])
         }
         let sorted = pairs.sorted { a, b in
-            let aEffective = max(a.usage?.sessionPercent ?? 0, a.usage?.weeklyAllPercent ?? 0)
-            let bEffective = max(b.usage?.sessionPercent ?? 0, b.usage?.weeklyAllPercent ?? 0)
+            // An absent window contributes nothing (rather than a fabricated
+            // 0%), so an OpenAI account reporting only a weekly figure ranks on
+            // that figure. Unchanged for Anthropic rows, which always carry both.
+            let aWindows = a.usage?.rateLimit
+            let bWindows = b.usage?.rateLimit
+            let aEffective = max(aWindows?.session?.usedPercent ?? 0, aWindows?.weekly?.usedPercent ?? 0)
+            let bEffective = max(bWindows?.session?.usedPercent ?? 0, bWindows?.weekly?.usedPercent ?? 0)
             if aEffective != bEffective { return aEffective < bEffective }
             return UsageStore.resetSeconds(a.usage) < UsageStore.resetSeconds(b.usage)
         }
@@ -335,10 +487,15 @@ class UsageStore: ObservableObject {
             isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
             let nowString = isoFormatter.string(from: Date())
 
-            // Load accounts using raw SQL
-            let accountStmt = try db.prepare(
-                "SELECT id, account_name, email, plan, last_updated FROM accounts ORDER BY last_updated DESC"
-            )
+            // Load accounts using raw SQL. `provider` is selected only when the
+            // column exists, so a database that hasn't been migrated yet (an
+            // external tool opened it first) still loads — every row then
+            // resolves to the .anthropic fallback.
+            let hasProvider = tableColumns(db, "accounts").contains("provider")
+            let accountStmt = try db.prepare("""
+                SELECT id, account_name, email, plan, last_updated\(hasProvider ? ", provider" : "")
+                FROM accounts ORDER BY last_updated DESC
+            """)
 
             for row in accountStmt {
                 guard let accountId = row[0] as? String else { continue }
@@ -346,6 +503,7 @@ class UsageStore: ObservableObject {
                 let acctEmail = row[2] as? String
                 let acctPlan = row[3] as? String
                 let acctLastUpdated = row[4] as? String
+                let acctProvider = AccountProvider(stored: hasProvider ? row[5] as? String : nil)
 
                 // Get latest percent from usage_history
                 var percent: Double? = nil
@@ -358,6 +516,7 @@ class UsageStore: ObservableObject {
 
                 let account = Account(
                     id: accountId,
+                    provider: acctProvider,
                     accountName: acctName,
                     email: acctEmail,
                     plan: acctPlan,
@@ -733,6 +892,7 @@ class UsageStore: ObservableObject {
                 let oldAccount = accounts[index]
                 let updatedAccount = Account(
                     id: oldAccount.id,
+                    provider: oldAccount.provider,
                     accountName: newName,
                     email: backfilledEmail ?? oldAccount.email,
                     plan: oldAccount.plan,

--- a/menubar-app/ClaudeMonitor/Sources/main.swift
+++ b/menubar-app/ClaudeMonitor/Sources/main.swift
@@ -56,6 +56,8 @@ enum ClaudeMonitorEntry {
         // without also passing --headless.
         if CommandLine.arguments.dropFirst().first == "accounts" {
             AccountSyncCLI.main(Array(CommandLine.arguments.dropFirst(2)))
+        } else if CommandLine.arguments.dropFirst().first == "selftest" {
+            SelfTest.main(Array(CommandLine.arguments.dropFirst(2)))
         } else if CommandLine.arguments.contains("--headless") {
             HeadlessRunner.main()
         } else {


### PR DESCRIPTION
## Summary

Phase 2 of the multi-provider epic (#25): make the data model and client layer provider-agnostic so the OpenAI/Codex poller can plug in during phase 3. **No OpenAI network calls ship here** — this is a refactor plus schema work, designed against the live-verified contract in `docs/spikes/2026-07-30-codex-usage-probe.md` § "Live verification (AUTHORITATIVE)".

## Changes

**Shared rate-limit model** — new `Sources/RateLimitWindow.swift`
- `AccountProvider` (`anthropic` | `openai`) with a tolerant parse: absent, blank, or unrecognized values resolve to `.anthropic` so a strange row can never take the poll loop down.
- `RateLimitWindow` (usedPercent / durationSeconds / resetAt / status) and `RateLimitSnapshot` (optional session + optional weekly + named sub-limits).
- **Window kind is derived from the window's duration, never its position.** `RateLimitSnapshot(windows:)` files an unordered list into buckets, so OpenAI's `[primary_window, secondary_window]` lands correctly even though the verified probe returned a *weekly* `primary_window` with `secondary_window: null`.
- **Every window is optional**, end to end: NULL stays NULL in the DB, `headroomScore` returns nil (not a misleading 100), the popover renders "—".

**Provider protocol** — new `Sources/UsageProviderClient.swift`
- `UsageProviderClient` + `ProviderCredentials` / `ProviderUsageSnapshot` / `ProviderAPIError`.
- `AnthropicAPIError` becomes a typealias for `ProviderAPIError`, so every existing `catch AnthropicAPIError.unauthorized` site compiles unchanged.
- `AnthropicAPIClient` conforms as a pure adaptation layer over `pingToken` / `identifyToken`. `refreshCredentials` defaults to nil — correct for Anthropic's ~1yr tokens; OpenAI's ~10-day tokens override it in phase 3.

**Schema migration**
- `accounts.provider`, `oauth_credentials.provider`, `oauth_credentials.token_expires_at` (plus an idempotent `refresh_token` heal). Added with `ADD COLUMN ... NOT NULL DEFAULT 'anthropic'`, so existing rows backfill in place, plus a healing `UPDATE` for blank values — the #15/#23 heal-on-launch precedent, not a re-add-your-accounts migration.
- Credential columns live on `oauth_credentials`, **not** `accounts`: that is already the table holding token material, and `accounts` is read directly by `RankingExporter`, which must never see a secret.
- `token_expires_at` is ISO 8601 (matching `token_rolled_at`), deliberately distinct from the vestigial epoch-ms `expires_at` column this app has never written.
- Schema/migration extracted into `UsageStore.applySchema(_:)` so `AccountSync.importBundle` and the self-test can run it against an arbitrary database.
- Read paths (`loadFromDatabase`, `loadActiveCredentials`, `AccountSync.exportBundle`) select the new columns only when present, so a database opened before migration still loads.
- `AccountSync` export/import round-trips provider + token expiry; both fields are optional, so `formatVersion` stays 1 and old bundles still import (resolving to Anthropic).

**Reading through the model**
- `UsageRecord.rateLimit` exposes a stored reading as a `RateLimitSnapshot`; `headroomScore` moved from the macOS-only popover into the portable core and now delegates to it, so the headless Linux daemon scores accounts identically.
- Popover percent cells, reset cells, and the session/weekly/reset sort keys all read through the window model.

**Testing** — new `ClaudeMonitor selftest` subcommand
There is no XCTest target (the package has zero dependencies by design), so tests ship as a portable, network-free, credential-free subcommand that exits non-zero on failure and is wired into CI on **both** macOS and Linux.

## Acceptance Criteria Verification

- [x] **Migration adds `provider` / `refresh_token` / `token_expires_at`; existing accounts continue to work with no user action, verified by launching against a pre-migration `usage.db`.** Verified two ways: (1) the self-test synthesizes the exact v1.17.0 pre-#28 schema, populates it, migrates, and asserts column presence, `anthropic` backfill, idempotency, and that the account still loads; (2) `selftest --db <copy>` was run against a copy of the live 12-account `~/.claude-monitor/usage.db` — all 12 migrated, every row backfilled to `anthropic`, per-account headroom scores byte-identical before and after.
- [x] **A shared rate-limit window type exists and Anthropic polling populates it; headroom score and popover read through it.** `PingResponse.rateLimit` builds the snapshot; `writePingToDB`, `headroomScore`, `sortedAccountsForPopover`, `UsageStore.resetSeconds`, and every popover percent/reset cell and sort key read through it.
- [x] **A missing session window renders sensibly (no crash, no misleading 0%).** Covered by `testMissingSessionWindow` and `testSnapshotFromPositionalWindows`: a weekly-only reading scores off the weekly window, a window-less reading yields `nil` headroom, and the popover's `percentText`/`resetLabel` render "—" for nil.
- [x] **`swift build` clean on macOS and the Linux headless target.** Both build clean (only the pre-existing `UpdateChecker` capture-`self` and unused-`data` warnings). Portable core is free of AppKit/SwiftUI/Combine/os.Logger — grepped; `UsagePopoverView.swift` remains the only touched file with `import SwiftUI`, still inside its `#if os(macOS)` fence.
- [x] **No behavior change for Anthropic-only users.** `writePingToDB` keeps the `?? 0` coercion so stored values are unchanged; `sortedAccountsForPopover` keeps its `?? 0` comparison semantics; `AnthropicAPIError` is preserved as a typealias; the poll loop still calls `pingToken` directly.

## Test Plan

```
cd menubar-app/ClaudeMonitor
swift build && .build/debug/ClaudeMonitor selftest          # 44 checks pass (macOS)
cp ~/.claude-monitor/usage.db /tmp/ && .build/debug/ClaudeMonitor selftest --db /tmp/usage.db
                                                            # 62 checks pass, 12 real accounts migrated
docker run --rm -v "$PWD":/src -w /src swift:6.1 bash -c \
  'apt-get update -qq && apt-get install -y -qq libsqlite3-dev && \
   swift build --scratch-path /tmp/build && /tmp/build/debug/ClaudeMonitor selftest && \
   /tmp/build/debug/ClaudeMonitor --once'                   # Linux: build + 44 checks + smoke run
```

The self-test was also confirmed to *fail* correctly: inverting the session/weekly duration boundary produced 4 failures and exit 1.

## Notes for the reviewer

- **Slight scope extension:** `AccountSync` export/import was updated to carry `provider` / `tokenExpiresAt`. Without it, multi-host sync would silently reset an OpenAI account to `anthropic` on import once phase 3 lands. Fields are optional, so v1 bundles are unaffected.
- **One rendering nuance:** the popover's reset cell previously echoed an unparseable reset string verbatim; it now shows "—". Only ISO 8601 values are written by this app, so this is unreachable in practice.
- Out of scope per the issue and untouched: the OpenAI network path, `/wham/usage` client, `auth.openai.com/oauth/token` refresh call, `provider` in `ranking.json`, and the popover provider badge.

Closes #28