### PR TITLE
feat: poll OpenAI/Codex usage and tag ranking.json with provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,14 +34,16 @@
   - `Sources/RateLimitWindow.swift` - Provider-agnostic rate-limit model (`AccountProvider`, `RateLimitWindow`, `RateLimitSnapshot`). Window kind is **derived from the window's duration**, never its position in the provider response, and every window is optional — an account may legitimately report no session window.
   - `Sources/UsageProviderClient.swift` - `UsageProviderClient` protocol + `ProviderCredentials` / `ProviderUsageSnapshot` / `ProviderAPIError` (aliased as `AnthropicAPIError`)
   - `Sources/AnthropicAPI.swift` - API client (usage, profile, token refresh); conforms to `UsageProviderClient`
-  - `Sources/OAuthPoller.swift` - Ping-based usage polling, token add/import, Fable probes
-  - `Sources/SelfTest.swift` - `ClaudeMonitor selftest`: portable-core assertions (window model, schema migration) with no network/credentials. Run in CI on both macOS and Linux; there is no XCTest target because the package has zero dependencies.
+  - `Sources/OpenAIAPI.swift` - OpenAI/Codex client: `GET chatgpt.com/backend-api/wham/usage` (never `/backend-api/codex/usage` — Cloudflare-challenged), `POST auth.openai.com/oauth/token` refresh, and `CodexAuth` (reads `~/.codex/auth.json`, honoring `$CODEX_HOME`). Access tokens live ~10 days; expiry comes from the token's own `exp` claim. **Never log a token or a raw response body** — `OpenAIUsageResponse.flatten` redacts PII/credential keys at *every* nesting depth before anything is archived or logged.
+  - `Sources/CodexCLI.swift` - `claude-monitor codex import` (one-shot CLI, no `--headless` needed, works on Linux)
+  - `Sources/OAuthPoller.swift` - Per-provider usage polling (Anthropic ping / OpenAI usage GET), token add/import, proactive OpenAI token refresh, Fable probes (Anthropic only). Absent windows are stored as NULL, not 0, for non-Anthropic providers.
+  - `Sources/SelfTest.swift` - `ClaudeMonitor selftest`: portable-core assertions (window model, schema migration, OpenAI wire mapping + PII redaction, `ranking.json` provider field) with no network/credentials. Run in CI on both macOS and Linux; there is no XCTest target because the package has zero dependencies. `--wire <path>` decodes a captured `/wham/usage` body offline (prints only derived numbers, never identity).
+  - `Sources/RankingExporter.swift` - Emits `~/.claude-monitor/ranking.json`. Every account carries `provider`; `schema` stays **1** because the field is additive. A `provider: openai` account may omit `utilization["5h"]` — consumers must read a missing key as *unknown*, never 0.
   - `Sources/UsagePopoverView.swift` - Summary-table popover, sortable headers, add-account dialog
   - `Sources/UsageChartView.swift` - Per-account usage-history chart window
   - `Sources/RollTokenView.swift` / `Sources/TokenRoller.swift` - Roll Token wizard + revoke-script generator. The workflow depends on undocumented, web-session-cookie-authenticated `claude.ai/api/oauth` endpoints; if they change, `TokenRoller.revokeAllScript` is the single place to update (see README "Rolling a Token").
   - `Sources/UsageStore.swift` - SQLite-backed data store, account/usage models
   - `Sources/SQLiteDB.swift` - Minimal wrapper over system libsqlite3 (zero package deps)
-  - `Sources/RankingExporter.swift` - Emits `~/.claude-monitor/ranking.json`
   - `Sources/FileLogger.swift` - Debug log at `~/.claude-monitor/debug.log`
   - `Assets/` - App icon (`AppIcon.icns` + 1024px master PNG + `icon-master.source.json` generation recipe)
 - `scripts/build-macos-app.sh` - Build script that compiles and creates the .app bundle (bundles the icon)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ OAuth tokens you provide, and renders the data locally on your Mac.
 - **Multi-account.** Add accounts one-by-one via a token from
   `claude setup-token`, or bulk-import from a `.env` file with
   `ACCOUNT_EMAIL_N` / `ACCOUNT_KEY_N` pairs.
+- **Multi-provider.** Anthropic and OpenAI/ChatGPT (Codex) accounts sit side by
+  side in the same table, each row tagged with a provider badge. See
+  [Adding an OpenAI (Codex) Account](#adding-an-openai-codex-account).
 - **Roll Token wizard.** Guided revoke-all + re-mint for an account's
   long-lived token (right-click its row → "Roll Token…"). A temporary stopgap
   until Anthropic ships a token-management API — see
@@ -114,6 +117,52 @@ and **appends** any new emails), then imports the result. Loading is
 **additive**: accounts in the lists are added or have their token refreshed, but
 accounts already in the app that aren't listed are left untouched — nothing is
 removed. Store these files with `chmod 600`; they contain live tokens.
+
+### Adding an OpenAI (Codex) Account
+
+ChatGPT subscription accounts (Plus/Pro, the ones Codex CLI uses) are polled
+too. Their usage comes from a dedicated read-only endpoint —
+`GET https://chatgpt.com/backend-api/wham/usage`, the same one Codex CLI's own
+`/usage` command calls — so no inference request is burned to read it.
+
+A ChatGPT credential is not a single pasteable string (it's an access token +
+refresh token + expiry), so it's **imported** from Codex CLI's own credential
+store rather than typed in:
+
+```bash
+codex login                    # once, if you haven't already
+claude-monitor codex import    # or: Add Account → "Import Codex Account"
+```
+
+The importer reads `$CODEX_HOME/auth.json` when `CODEX_HOME` is set, otherwise
+`~/.codex/auth.json`. Pass `--auth <path>` to read a different file. The
+credential is validated against the live usage endpoint before it's stored, and
+the account's email, plan, and OpenAI account id all come back in that same
+response — there's no separate profile call.
+
+What differs from an Anthropic row once it's added:
+
+- **Session % may be blank.** OpenAI reports its windows as
+  `primary_window` / `secondary_window`, each carrying its own length, and a
+  ChatGPT Pro account can legitimately report only a **weekly** window. When
+  there's no session window, the Session cells show `—`. That is a real
+  "unknown", not 0% — the headroom score and sorting use whichever windows
+  actually exist.
+- **Fable Left / Extra are always `—`.** Those columns track Anthropic premium
+  tiers; the Fable probe is skipped for OpenAI accounts entirely.
+- **Tokens expire, and are renewed for you.** An OpenAI access token lives
+  about 10 days. The poller renews it from the stored refresh token
+  *proactively* — 6 hours ahead of expiry, never waiting for a 401 — and the
+  Token dot reports the outcome: green (healthy), **yellow** (renewal is
+  failing but the current token still works; hover for the reason), **red**
+  (expired and unrenewable — re-run `claude-monitor codex import`). A stale
+  OpenAI account never fails silently.
+
+> **Note on refresh-token rotation.** If OpenAI issues a new refresh token
+> during renewal, this app stores it in its own database; it does **not** write
+> back to `~/.codex/auth.json`. Should Codex CLI ever start reporting a bad
+> credential after this app has been running a while, re-run `codex login` and
+> then `claude-monitor codex import`.
 
 ### Rolling a Token (revoke + re-mint)
 
@@ -226,22 +275,28 @@ against `/v1/messages`.
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│  OAuth tokens                                                            │
-│    - `claude setup-token` (single, paste-in)                             │
-│    - `.env` bulk import (ACCOUNT_EMAIL_N / ACCOUNT_KEY_N)                │
+│  OAuth credentials                                                       │
+│    - `claude setup-token` (single, paste-in)            [anthropic]      │
+│    - `.env` bulk import (ACCOUNT_EMAIL_N / ACCOUNT_KEY_N) [anthropic]    │
+│    - `claude-monitor codex import` (~/.codex/auth.json)   [openai]       │
 └────────────────────────────────┬─────────────────────────────────────────┘
                                  │ stored in
                                  ▼
 ┌──────────────────────────────────────────────────────────────────────────┐
 │  SQLite — ~/.claude-monitor/usage.db                                     │
 │    accounts │ oauth_credentials │ usage_history │ settings               │
+│    (accounts.provider / oauth_credentials.provider tag the upstream)     │
 └────────────────────────────────┬─────────────────────────────────────────┘
                                  │ read by
                                  ▼
 ┌──────────────────────────────────────────────────────────────────────────┐
-│  OAuthPoller → Anthropic API                                             │
-│    - Each account pinged once per 10 min (staggered)                     │
-│    - Tokens are long-lived (1 yr); no refresh dance needed               │
+│  OAuthPoller — one client per provider, one shared window model          │
+│    anthropic: POST /v1/messages (1-token ping) → rate-limit headers      │
+│               tokens are long-lived (~1 yr); no refresh dance needed     │
+│    openai:    GET /backend-api/wham/usage → rate_limit.{primary,         │
+│               secondary}_window; access tokens live ~10 days and are     │
+│               refreshed proactively via auth.openai.com/oauth/token      │
+│    - Each account polled once per 10 min (staggered)                     │
 └────────────────────────────────┬─────────────────────────────────────────┘
                                  │ data drives
                                  ▼
@@ -364,6 +419,59 @@ claude-monitor accounts import accounts.json
   build: `ClaudeMonitor accounts export ...`.
 
 Run `claude-monitor accounts --help` for the full flag list.
+
+## Ranking Export (`ranking.json`)
+
+After every poll cycle the app writes a small, **non-secret**, email-keyed
+snapshot to `~/.claude-monitor/ranking.json` for external multi-account load
+balancers (notably `loom-daemon`, which uses it to pick a token). It's written
+atomically, so a reader never sees a partial document.
+
+```jsonc
+{
+  "schema": 1,
+  "generated_at": "2026-07-30T18:00:00Z",
+  "accounts": [
+    {
+      "email":       "you@example.com",   // the join key
+      "provider":    "anthropic",         // "anthropic" | "openai"
+      "plan":        "max_20x",
+      "status":      "available",         // available | rate_limited | exhausted | blocked
+      "utilization": { "5h": 0.12, "7d": 0.44 },   // 0.0–1.0
+      "resets":      { "5h": "…Z", "7d": "…Z" },
+      "models":      { "fable": { "utilization": 0.30 } },   // optional
+      "updated_at":  "2026-07-30T17:58:00Z"
+    },
+    {
+      "email":       "you@example.com",
+      "provider":    "openai",
+      "plan":        "pro",
+      "status":      "available",
+      "utilization": { "7d": 0.14 },      // note: no "5h" key — see below
+      "resets":      { "7d": "…Z" },
+      "updated_at":  "2026-07-30T17:58:00Z"
+    }
+  ]
+}
+```
+
+**Schema change for consumers (added with OpenAI support):**
+
+- **`provider` is new and additive.** It is emitted for *every* account and is
+  `"anthropic"` or `"openai"`; accounts that predate multi-provider support
+  report `"anthropic"`. `schema` stays **1** on purpose — the version number
+  tracks breaking changes, and adding an optional key breaks nobody. A consumer
+  that ignores `provider` behaves exactly as it did before. Treat an unrecognized
+  future value as "some other provider" rather than rejecting the document.
+- **`utilization["5h"]` can be absent on an `openai` account.** The ChatGPT
+  usage endpoint may report a weekly window and no session window at all.
+  A missing key means **unknown**, not `0.0` — reading it as zero would make an
+  account look like it has full session capacity. The same applies to
+  `resets["5h"]`. (Anthropic accounts always report both windows.)
+- Accounts with a `NULL` email are still excluded entirely; `email` remains the
+  sole join key, and it is not unique across providers — one person's Anthropic
+  and OpenAI accounts can share an address, distinguished by `provider`.
+- No credential material ever appears in this file.
 
 ## Auto-Start on Login (Optional)
 
@@ -496,8 +604,13 @@ claude-monitor/
 │       ├── SQLiteDB.swift          # Minimal system-libsqlite3 wrapper (zero deps)
 │       ├── UsagePopoverView.swift  # Summary table, sortable headers, add-account dialog
 │       ├── UsageChartView.swift    # Per-account chart window
-│       ├── OAuthPoller.swift       # API pings, token add/import, token rolling
-│       ├── AnthropicAPI.swift      # API client
+│       ├── OAuthPoller.swift       # Per-provider polling, token add/import/refresh
+│       ├── AnthropicAPI.swift      # Anthropic client (ping + rate-limit headers)
+│       ├── OpenAIAPI.swift         # OpenAI/Codex client (wham/usage + token refresh)
+│       ├── CodexCLI.swift          # `claude-monitor codex import` CLI surface
+│       ├── RateLimitWindow.swift   # Provider-agnostic window/snapshot model
+│       ├── UsageProviderClient.swift # UsageProviderClient protocol + credentials
+│       ├── SelfTest.swift          # `claude-monitor selftest` portable-core assertions
 │       ├── RollTokenView.swift     # Roll Token wizard window (rotate long-lived tokens)
 │       ├── TokenRoller.swift       # Revoke-all browser-console script generator
 │       ├── RankingExporter.swift   # Emits ~/.claude-monitor/ranking.json for load balancers

--- a/docs/spikes/2026-07-30-codex-usage-probe.md
+++ b/docs/spikes/2026-07-30-codex-usage-probe.md
@@ -312,17 +312,55 @@ Authorization: Bearer <access_token from ~/.codex/auth.json>
    Fable tracking, and is a better-structured source than what Anthropic
    exposes.
 
+### Refresh endpoint (2026-07-30, phase 3) — request contract verified
+
+Phase 3 probed `POST https://auth.openai.com/oauth/token` with the **exact**
+request the shipped client sends, but a deliberately invalid `refresh_token`:
+
+```jsonc
+// Content-Type: application/json
+{ "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",  // Codex CLI's public client id
+  "grant_type": "refresh_token",
+  "refresh_token": "rt.invalid-probe-value-not-a-real-token",
+  "scope": "openid profile email" }
+```
+
+```jsonc
+// HTTP 401
+{ "error": { "message": "Invalid refresh token.",
+             "type": "invalid_request_error",
+             "param": null,
+             "code": "invalid_refresh_token" } }
+```
+
+What this establishes, and what it doesn't:
+
+- **Established:** the endpoint exists and accepts a **JSON** (not
+  form-encoded) body; the `client_id` and `grant_type` are accepted — a bad
+  client id answers `invalid_client` and a bad grant type
+  `unsupported_grant_type`, and neither happened. Only the token itself was
+  rejected. The error body is **nested** (`error.code`), not the flat RFC 6749
+  `{"error": "..."}` string, which is what the client's error extraction had to
+  be written against.
+- **Not established:** a *successful* exchange. It was deliberately not run:
+  OAuth refresh may rotate the refresh token, which would invalidate the copy
+  in `~/.codex/auth.json` and break the operator's Codex CLI login. The client
+  therefore handles both outcomes — it keeps the stored refresh token when the
+  reply carries none, and replaces it when one comes back — and surfaces any
+  refresh failure as a visible token-health state rather than polling on
+  silently.
+
 ### Still unverified
 
 - Cost/quota impact of polling this endpoint (it returned instantly and is
   what the CLI's own `/usage` hits, so it is very likely free, but no
   before/after quota comparison was made).
-- The `refresh_token` flow against `auth.openai.com/oauth/token` was **not**
-  exercised — the 10-day access-token lifetime finding above still stands as
-  the phase-2 design driver, but the refresh call itself remains untested.
+- A **successful** `refresh_token` exchange (see above) — and, consequently,
+  whether OpenAI rotates refresh tokens for this client.
 - Whether `secondary_window` populates on plans/accounts that do have an
   active 5h window (see finding 1) — worth re-probing when a session window is
-  actually in use.
+  actually in use. Re-confirmed on 2026-07-30: still `null` on this Pro
+  account, with a weekly `primary_window` at 14%.
 
 ## References
 

--- a/menubar-app/ClaudeMonitor/Sources/CodexCLI.swift
+++ b/menubar-app/ClaudeMonitor/Sources/CodexCLI.swift
@@ -59,36 +59,42 @@ enum CodexCLI {
             fail("No Codex credential at \(resolved) — run `codex login` first, or pass --auth <path>")
         }
 
+        // Freeze the parsed option into an immutable binding: everything the
+        // Task below touches must be a `let`. Strict concurrency checking
+        // rejects both mutating *and* merely referencing a captured `var` from
+        // concurrently-executing code, and the Xcode toolchain on CI's macOS
+        // runner enforces that as an error where newer ones only warn.
+        let storePath = dbPath
+
         // The import validates the credential against the live usage endpoint,
         // so the database must exist before the account row is written.
-        let store = UsageStore(dbPath: dbPath)
+        let store = UsageStore(dbPath: storePath)
         store.ensureDatabase()
 
-        let poller = OAuthPoller(dbPath: dbPath)
-        let semaphore = DispatchSemaphore(value: 0)
-        var result: (accountId: String?, error: String?) = (nil, nil)
+        let poller = OAuthPoller(dbPath: storePath)
 
+        // Bridge sync → async the way HeadlessRunner does: the whole
+        // continuation lives inside the Task, which ends the process itself,
+        // so no value is handed back across the concurrency boundary.
         Task {
-            result = await poller.importCodexCredential(path: resolved)
-            semaphore.signal()
-        }
-        semaphore.wait()
-
-        if let accountId = result.accountId {
+            let result = await poller.importCodexCredential(path: resolved)
+            guard let accountId = result.accountId else {
+                fail(result.error ?? "Import failed")
+            }
             print("Imported OpenAI account \(accountId.prefix(8))… from \(resolved)")
-            if let dbPath = dbPath {
+            if let storePath = storePath {
                 // Keep a scratch run entirely inside the scratch directory —
                 // never overwrite the real ranking.json from a test import.
                 RankingExporter.exportNow(
-                    dbPath: dbPath,
-                    outputPath: (dbPath as NSString).deletingLastPathComponent + "/ranking.json"
+                    dbPath: storePath,
+                    outputPath: (storePath as NSString).deletingLastPathComponent + "/ranking.json"
                 )
             } else {
                 RankingExporter.exportNow()
             }
             exit(0)
         }
-        fail(result.error ?? "Import failed")
+        dispatchMain()
     }
 
     private static func fail(_ message: String) -> Never {

--- a/menubar-app/ClaudeMonitor/Sources/CodexCLI.swift
+++ b/menubar-app/ClaudeMonitor/Sources/CodexCLI.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// `claude-monitor codex import` — bring an OpenAI/ChatGPT (Codex) credential
+/// into the app from Codex CLI's own credential store.
+///
+/// A one-shot CLI operation like `accounts export|import`: no `--headless`
+/// flag, no GUI, identical on macOS and Linux, so a headless Loom host can add
+/// an OpenAI account with `codex login && claude-monitor codex import`.
+///
+/// Nothing here ever prints a token or an email address; the account is
+/// identified in output by the first 8 characters of its OpenAI `account_id`.
+enum CodexCLI {
+    /// `args` is everything after the `codex` subcommand itself.
+    static func main(_ args: [String]) -> Never {
+        guard let sub = args.first else {
+            printUsage()
+            exit(2)
+        }
+
+        switch sub {
+        case "import":
+            runImport(Array(args.dropFirst()))
+        case "--help", "-h", "help":
+            printUsage()
+            exit(0)
+        default:
+            FileHandle.standardError.write(Data("Unknown 'codex' subcommand '\(sub)'\n\n".utf8))
+            printUsage()
+            exit(2)
+        }
+    }
+
+    private static func runImport(_ args: [String]) -> Never {
+        var authPath: String?
+        var dbPath: String?
+
+        var i = 0
+        while i < args.count {
+            switch args[i] {
+            case "--auth":
+                guard i + 1 < args.count else { fail("--auth requires a path") }
+                authPath = args[i + 1]
+                i += 1
+            case "--db":
+                guard i + 1 < args.count else { fail("--db requires a path") }
+                dbPath = args[i + 1]
+                i += 1
+            case "--help", "-h":
+                printUsage()
+                exit(0)
+            default:
+                fail("Unknown option '\(args[i])' (see --help)")
+            }
+            i += 1
+        }
+
+        let resolved = authPath ?? CodexAuth.defaultAuthPath
+        guard FileManager.default.fileExists(atPath: resolved) else {
+            fail("No Codex credential at \(resolved) — run `codex login` first, or pass --auth <path>")
+        }
+
+        // The import validates the credential against the live usage endpoint,
+        // so the database must exist before the account row is written.
+        let store = UsageStore(dbPath: dbPath)
+        store.ensureDatabase()
+
+        let poller = OAuthPoller(dbPath: dbPath)
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: (accountId: String?, error: String?) = (nil, nil)
+
+        Task {
+            result = await poller.importCodexCredential(path: resolved)
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        if let accountId = result.accountId {
+            print("Imported OpenAI account \(accountId.prefix(8))… from \(resolved)")
+            if let dbPath = dbPath {
+                // Keep a scratch run entirely inside the scratch directory —
+                // never overwrite the real ranking.json from a test import.
+                RankingExporter.exportNow(
+                    dbPath: dbPath,
+                    outputPath: (dbPath as NSString).deletingLastPathComponent + "/ranking.json"
+                )
+            } else {
+                RankingExporter.exportNow()
+            }
+            exit(0)
+        }
+        fail(result.error ?? "Import failed")
+    }
+
+    private static func fail(_ message: String) -> Never {
+        FileHandle.standardError.write(Data("Error: \(message)\n".utf8))
+        exit(1)
+    }
+
+    private static func printUsage() {
+        print("""
+            claude-monitor codex — import an OpenAI/ChatGPT (Codex) credential
+            so its usage is polled alongside Anthropic accounts.
+
+            Usage:
+              claude-monitor codex import [--auth <path>] [--db <path>]
+
+            Reads Codex CLI's credential store — $CODEX_HOME/auth.json when
+            CODEX_HOME is set, otherwise ~/.codex/auth.json — validates it
+            against the ChatGPT usage endpoint, and stores the account plus its
+            access/refresh tokens and expiry. Run `codex login` first if the
+            file doesn't exist yet.
+
+            OpenAI access tokens live about 10 days. The poller renews them
+            proactively from the stored refresh token; if renewal ever fails,
+            the account's token dot turns yellow (still valid, renewal failing)
+            or red (expired) rather than silently going stale. Re-running this
+            command re-imports a fresh credential.
+
+            --auth <path> reads an alternate auth.json, and --db <path>
+            overrides ~/.claude-monitor/usage.db (writing ranking.json beside
+            it) — both mainly for testing the import end to end without
+            touching the real store.
+            """)
+    }
+}

--- a/menubar-app/ClaudeMonitor/Sources/HeadlessMain.swift
+++ b/menubar-app/ClaudeMonitor/Sources/HeadlessMain.swift
@@ -9,6 +9,8 @@ enum ClaudeMonitorEntry {
         // the always-on poll loop below.
         if CommandLine.arguments.dropFirst().first == "accounts" {
             AccountSyncCLI.main(Array(CommandLine.arguments.dropFirst(2)))
+        } else if CommandLine.arguments.dropFirst().first == "codex" {
+            CodexCLI.main(Array(CommandLine.arguments.dropFirst(2)))
         } else if CommandLine.arguments.dropFirst().first == "selftest" {
             SelfTest.main(Array(CommandLine.arguments.dropFirst(2)))
         } else {

--- a/menubar-app/ClaudeMonitor/Sources/HeadlessRunner.swift
+++ b/menubar-app/ClaudeMonitor/Sources/HeadlessRunner.swift
@@ -96,9 +96,16 @@ enum HeadlessRunner {
             return
         }
         let parts = store.sortedAccountsForPopover.map { account -> String in
-            guard let usage = store.latestUsage[account.id] else { return "\(account.displayName): ?" }
-            let pct = Int(max(usage.sessionPercent ?? 0, usage.weeklyAllPercent ?? 0))
-            return "\(account.displayName): \(pct)%"
+            let label = "[\(account.provider.shortCode)] \(account.displayName)"
+            // Read through the shared window model: an account whose provider
+            // reports only a weekly window shows that figure rather than a
+            // fabricated 0% session.
+            guard let windows = store.latestUsage[account.id]?.rateLimit,
+                  let used = [windows.session?.usedPercent, windows.weekly?.usedPercent]
+                      .compactMap({ $0 }).max() else {
+                return "\(label): ?"
+            }
+            return "\(label): \(Int(used))%"
         }
         flog.info("Usage — " + parts.joined(separator: ", "), category: "Headless")
     }
@@ -136,6 +143,8 @@ enum HeadlessRunner {
 
         Subcommands:
           accounts            Export/import accounts + credentials
+          codex               Import an OpenAI/Codex credential from
+                              ~/.codex/auth.json (honors $CODEX_HOME)
           selftest            Run portable-core assertions (no network, no
                               credentials; exits non-zero on failure)
         """

--- a/menubar-app/ClaudeMonitor/Sources/OAuthPoller.swift
+++ b/menubar-app/ClaudeMonitor/Sources/OAuthPoller.swift
@@ -101,6 +101,15 @@ struct OAuthCredential {
     }
 }
 
+/// Raised when a credential's access token is past expiry and could not be
+/// renewed. Distinct from `ProviderAPIError.unauthorized` so the retry loop can
+/// preserve the `.expired` token-health state (and its actionable message)
+/// instead of flattening it to the generic "revoked".
+struct CredentialExpiredError: Error, LocalizedError {
+    let reason: String
+    var errorDescription: String? { reason }
+}
+
 struct EnvImportResult {
     let email: String
     let success: Bool
@@ -109,12 +118,29 @@ struct EnvImportResult {
 
 class OAuthPoller: ObservableObject {
     private let apiClient = AnthropicAPIClient()
+    private let openAIClient = OpenAIAPIClient()
     @Published var lastError: String?
     @Published var credentialStatuses: [CredentialStatus] = []
 
-    private var dbPath: String {
-        FileManager.default.homeDirectoryForCurrentUser
+    private let dbPath: String
+
+    /// `dbPath` defaults to `~/.claude-monitor/usage.db`. An explicit path lets
+    /// the CLI (and tests) exercise the real add/poll paths against a throwaway
+    /// database — the same escape hatch `UsageStore(dbPath:)` provides, and the
+    /// only safe one: `homeDirectoryForCurrentUser` ignores a `HOME` override on
+    /// macOS, so redirecting via the environment silently hits the live store
+    /// (issue #16).
+    init(dbPath: String? = nil) {
+        self.dbPath = dbPath ?? FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".claude-monitor/usage.db").path
+    }
+
+    /// The client that speaks a given provider's protocol.
+    private func client(for provider: AccountProvider) -> UsageProviderClient {
+        switch provider {
+        case .anthropic: return apiClient
+        case .openai: return openAIClient
+        }
     }
 
     // MARK: - Add Account with Token
@@ -169,6 +195,84 @@ class OAuthPoller: ObservableObject {
         return (orgId, nil)
     }
 
+    // MARK: - Add OpenAI / Codex Account
+
+    /// Validate an OpenAI credential against `GET /backend-api/wham/usage`,
+    /// then create/update the account from the identity that same response
+    /// carries (`account_id`, `email`, `plan_type` — no separate profile call).
+    ///
+    /// Returns the OpenAI account id on success.
+    func addOpenAIAccount(
+        accessToken: String,
+        refreshToken: String? = nil,
+        expiresAt: Date? = nil
+    ) async -> (accountId: String?, error: String?) {
+        let accessToken = accessToken.filter { !$0.isWhitespace }
+        guard !accessToken.isEmpty else { return (nil, "Token is empty") }
+
+        var credentials = ProviderCredentials(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            // Fall back to the token's own `exp` claim when the caller has no
+            // stated expiry — an OpenAI access token lives ~10 days and the
+            // poller must know when to renew it.
+            expiresAt: expiresAt ?? OpenAIAPIClient.accessTokenExpiry(accessToken)
+        )
+
+        // Renew up front if the imported credential is already stale, so an
+        // account added from an old auth.json works immediately.
+        if credentials.isExpiring(within: refreshLeadTime), credentials.isRefreshable {
+            if let refreshed = try? await openAIClient.refresh(credentials) {
+                credentials = refreshed
+            }
+        }
+
+        let snapshot: ProviderUsageSnapshot
+        do {
+            snapshot = try await openAIClient.fetchUsage(credentials)
+        } catch {
+            flog.error("addOpenAIAccount: usage fetch failed: \(error.localizedDescription)", category: fcat)
+            return (nil, "Invalid OpenAI credential: \(error.localizedDescription)")
+        }
+
+        saveCredentialForAccount(
+            accountId: snapshot.accountKey,
+            email: snapshot.email,
+            orgName: nil,
+            plan: snapshot.plan ?? "ChatGPT",
+            accessToken: credentials.accessToken,
+            source: "codex",
+            provider: .openai,
+            refreshToken: credentials.refreshToken,
+            tokenExpiresAt: credentials.expiresAt
+        )
+
+        writeSnapshotToDB(accountId: snapshot.accountKey, snapshot: snapshot)
+
+        flog.info("addOpenAIAccount: account \(snapshot.accountKey.prefix(8))... plan \(snapshot.plan ?? "?")", category: fcat)
+        return (snapshot.accountKey, nil)
+    }
+
+    /// Import the credential Codex CLI stores at `~/.codex/auth.json` (or
+    /// `$CODEX_HOME/auth.json`). `path` overrides the location — the self-test
+    /// and CLI pass an explicit scratch path rather than relying on a `HOME`
+    /// override, which `FileManager.homeDirectoryForCurrentUser` ignores on
+    /// macOS (issue #16).
+    func importCodexCredential(path: String? = nil) async -> (accountId: String?, error: String?) {
+        let credential: CodexAuth.Credential
+        do {
+            credential = try CodexAuth.load(path: path)
+        } catch {
+            flog.error("importCodexCredential: \(error.localizedDescription)", category: fcat)
+            return (nil, error.localizedDescription)
+        }
+        return await addOpenAIAccount(
+            accessToken: credential.accessToken,
+            refreshToken: credential.refreshToken,
+            expiresAt: credential.expiresAt
+        )
+    }
+
     // MARK: - Import from .env File
 
     /// Parse a .env file for ACCOUNT_EMAIL_N / ACCOUNT_KEY_N pairs and import each.
@@ -212,6 +316,12 @@ class OAuthPoller: ObservableObject {
     /// ACCOUNT_KEY_N env format, the same format the Bulk Import field and the
     /// account list files accept. Returns nil if there are no exportable accounts
     /// (so the caller can disable the Copy button). Order follows sort_order.
+    ///
+    /// **Anthropic accounts only.** The env format carries a single long-lived
+    /// bearer string; an OpenAI credential is an access token + refresh token +
+    /// expiry, and pasting its access token back in would be re-imported down
+    /// the Anthropic path and fail. Those accounts move between hosts via
+    /// `claude-monitor accounts export/import`, which carries all three fields.
     func exportAccountsEnv() -> String? {
         guard FileManager.default.fileExists(atPath: dbPath) else { return nil }
         do {
@@ -221,6 +331,7 @@ class OAuthPoller: ObservableObject {
                 FROM oauth_credentials c
                 JOIN accounts a ON a.id = c.account_id
                 WHERE c.is_active = 1 AND c.access_token IS NOT NULL
+                  AND COALESCE(a.provider, 'anthropic') = 'anthropic'
                 ORDER BY a.sort_order, a.id
             """)
 
@@ -588,6 +699,9 @@ class OAuthPoller: ObservableObject {
         var probed = 0
 
         for credential in credentials {
+            // Fable is an Anthropic premium tier; other providers expose their
+            // per-model sub-limits in the usage response itself.
+            guard credential.provider == .anthropic else { continue }
             guard let accountId = credential.accountId,
                   let token = credential.accessToken else { continue }
             let last = lastFableProbeTimes[accountId]
@@ -617,6 +731,11 @@ class OAuthPoller: ObservableObject {
                 updateCredentialStatus(credential, status: .refreshing, error: "Retrying...")
                 try? await Task.sleep(nanoseconds: retryDelay)
                 retryDelay *= 2
+            } catch is CredentialExpiredError {
+                // The refresh path already recorded `.expired` plus an
+                // actionable message; retrying or downgrading it to the generic
+                // "revoked" would bury the reason. Stop here.
+                return
             } catch {
                 let isUnauthorized: Bool
                 if case AnthropicAPIError.unauthorized = error { isUnauthorized = true } else { isUnauthorized = false }
@@ -629,6 +748,15 @@ class OAuthPoller: ObservableObject {
     }
 
     private func pollSingle(_ credential: OAuthCredential) async throws {
+        switch credential.provider {
+        case .anthropic:
+            try await pollAnthropic(credential)
+        case .openai:
+            try await pollOpenAI(credential)
+        }
+    }
+
+    private func pollAnthropic(_ credential: OAuthCredential) async throws {
         guard let token = credential.accessToken else {
             updateCredentialStatus(credential, status: .missing, error: "No access token")
             throw AnthropicAPIError.unauthorized
@@ -650,58 +778,224 @@ class OAuthPoller: ObservableObject {
         }
     }
 
-    // MARK: - Write Ping Data to DB
+    private func pollOpenAI(_ credential: OAuthCredential) async throws {
+        guard let stored = credential.providerCredentials else {
+            updateCredentialStatus(credential, status: .missing, error: "No access token")
+            throw AnthropicAPIError.unauthorized
+        }
+
+        // Proactive, not reactive: renew ahead of expiry rather than waiting
+        // for a 401. Throws (loudly, with a visible token-health state) when the
+        // token is already dead and cannot be renewed.
+        let renewal = try await refreshIfNeeded(credential, stored)
+
+        let snapshot = try await openAIClient.fetchUsage(renewal.credentials)
+
+        // Prefer the stored account_id; fall back to the one the response
+        // carries so a credential imported before identification still lands.
+        let accountId = credential.accountId.flatMap { $0.isEmpty ? nil : $0 } ?? snapshot.accountKey
+        guard !accountId.isEmpty else {
+            flog.warning("Credential \(credential.label) has no account_id", category: fcat)
+            return
+        }
+
+        writeSnapshotToDB(accountId: accountId, snapshot: snapshot)
+
+        // A successful read does NOT clear a refresh warning: the usage figures
+        // are current, but the credential is still on a path to expiry that we
+        // could not renew. Surfacing that now (yellow dot + reason) is the whole
+        // point of refreshing proactively.
+        if let warning = renewal.warning {
+            updateCredentialLastPoll(credential, error: warning)
+            updateCredentialStatus(credential, status: .refreshing, error: warning)
+        } else {
+            updateCredentialLastPoll(credential, error: nil)
+            updateCredentialStatus(credential, status: .valid, error: nil)
+        }
+
+        await MainActor.run {
+            self.lastError = nil
+        }
+    }
+
+    // MARK: - Proactive Token Refresh
+
+    /// How far ahead of expiry a credential is renewed. Comfortably longer than
+    /// the poll interval, so a token never expires between two poll cycles.
+    let refreshLeadTime: TimeInterval = 6 * 3600
+
+    /// What `refreshIfNeeded` decided: the credential to poll with, plus a
+    /// non-nil `warning` when renewal was needed but didn't happen and the
+    /// current token is nonetheless still inside its validity window.
+    struct RenewalOutcome {
+        let credentials: ProviderCredentials
+        let warning: String?
+    }
+
+    /// Renew `credentials` when they are at or near expiry, persisting the
+    /// result. Anthropic credentials state no expiry and short-circuit here.
+    ///
+    /// Failure is **never silent**:
+    /// - token already past expiry and unrenewable → `.expired` (red dot) with
+    ///   an actionable message, and the caller throws rather than issuing a
+    ///   request with a token we already know is dead;
+    /// - renewal failed but the token is still valid → a `warning` the caller
+    ///   surfaces as `.refreshing` (yellow dot), and polling continues on the
+    ///   current token.
+    private func refreshIfNeeded(
+        _ credential: OAuthCredential,
+        _ credentials: ProviderCredentials
+    ) async throws -> RenewalOutcome {
+        guard credentials.isExpiring(within: refreshLeadTime) else {
+            return RenewalOutcome(credentials: credentials, warning: nil)
+        }
+
+        var reason: String
+        if !credentials.isRefreshable {
+            reason = "Access token expires soon and no refresh token is stored — re-import with `claude-monitor codex import`"
+        } else {
+            do {
+                if let refreshed = try await client(for: credential.provider)
+                    .refreshCredentials(credentials) {
+                    persistRefreshedCredential(credential, refreshed)
+                    return RenewalOutcome(credentials: refreshed, warning: nil)
+                }
+                // Provider has nothing to refresh (Anthropic's default).
+                return RenewalOutcome(credentials: credentials, warning: nil)
+            } catch {
+                reason = "Token refresh failed: \(error.localizedDescription)"
+            }
+        }
+
+        let alreadyExpired = credentials.expiresAt.map { $0 <= Date() } ?? false
+        if alreadyExpired {
+            updateCredentialLastPoll(credential, error: reason)
+            updateCredentialStatus(credential, status: .expired, error: reason)
+            flog.error("\(credential.label): \(reason) — token already expired, skipping poll", category: fcat)
+            throw CredentialExpiredError(reason: reason)
+        }
+
+        flog.warning("\(credential.label): \(reason) — token still valid, polling with it", category: fcat)
+        return RenewalOutcome(credentials: credentials, warning: reason)
+    }
+
+    /// Write a renewed access/refresh token pair back to `oauth_credentials`.
+    /// OpenAI rotates refresh tokens, so both halves are replaced together.
+    private func persistRefreshedCredential(_ credential: OAuthCredential, _ refreshed: ProviderCredentials) {
+        guard let credId = credential.id,
+              FileManager.default.fileExists(atPath: dbPath) else { return }
+        do {
+            let db = try openDatabase(dbPath)
+            let now = ISO8601DateFormatter().string(from: Date())
+            let expiryISO = refreshed.expiresAt.map { ISO8601DateFormatter().string(from: $0) }
+            try db.run("""
+                UPDATE oauth_credentials SET
+                    access_token = ?,
+                    refresh_token = COALESCE(?, refresh_token),
+                    token_expires_at = ?,
+                    is_active = 1, last_error = NULL,
+                    updated_at = ?, token_rolled_at = ?
+                WHERE id = ?
+            """, refreshed.accessToken, refreshed.refreshToken, expiryISO, now, now, credId)
+            flog.info("Persisted refreshed credential for \(credential.label)", category: fcat)
+        } catch {
+            flog.error("Failed to persist refreshed credential: \(error.localizedDescription)", category: fcat)
+        }
+    }
+
+    // MARK: - Write Usage Data to DB
 
     private func writePingToDB(accountId: String, ping: PingResponse) {
+        // `?? 0` preserves the long-standing Anthropic behavior of storing 0 for
+        // an absent header. Anthropic always reports both windows in practice,
+        // and existing history rows are all 0-filled, so keeping the coercion
+        // here avoids introducing NULLs into a series that has never had them.
+        let windows = ping.rateLimit
+        writeUsageToDB(
+            accountId: accountId,
+            sessionPercent: windows.session?.usedPercent ?? 0,
+            weeklyPercent: windows.weekly?.usedPercent ?? 0,
+            sessionReset: windows.session?.resetAtISO,
+            weeklyReset: windows.weekly?.resetAtISO,
+            rawFields: ping.rawHeaders,
+            probeModel: "haiku",
+            httpStatus: ping.httpStatus
+        )
+    }
+
+    /// Persist a provider-agnostic usage reading.
+    ///
+    /// Unlike the Anthropic path, an absent window is written as **NULL**, not
+    /// 0 — an OpenAI account may legitimately report no session window, and
+    /// storing 0 there would read downstream as "no session capacity used",
+    /// inflating the account's apparent headroom.
+    private func writeSnapshotToDB(accountId: String, snapshot: ProviderUsageSnapshot) {
+        let windows = snapshot.rateLimit
+        writeUsageToDB(
+            accountId: accountId,
+            sessionPercent: windows.session?.usedPercent,
+            weeklyPercent: windows.weekly?.usedPercent,
+            sessionReset: windows.session?.resetAtISO,
+            weeklyReset: windows.weekly?.resetAtISO,
+            rawFields: snapshot.rawFields,
+            probeModel: "\(snapshot.provider.rawValue)-usage",
+            httpStatus: snapshot.httpStatus
+        )
+    }
+
+    /// The single write path for both providers: one `usage_history` row plus a
+    /// verbatim `probe_snapshots` archive entry.
+    private func writeUsageToDB(
+        accountId: String,
+        sessionPercent: Double?,
+        weeklyPercent: Double?,
+        sessionReset: String?,
+        weeklyReset: String?,
+        rawFields: [String: String],
+        probeModel: String,
+        httpStatus: Int
+    ) {
         guard FileManager.default.fileExists(atPath: dbPath) else { return }
 
         do {
             let db = try openDatabase(dbPath)
             let now = ISO8601DateFormatter().string(from: Date())
 
-            // Read through the shared, provider-agnostic window model rather
-            // than the Anthropic-specific header fields. `?? 0` preserves the
-            // long-standing Anthropic behavior of storing 0 for an absent
-            // header; a provider-agnostic writer for genuinely window-less
-            // accounts (OpenAI with no session window) arrives with the phase-3
-            // poller, and the columns are already nullable for it.
-            let windows = ping.rateLimit
-            let sessionPercent = windows.session?.usedPercent ?? 0
-            let weeklyAllPercent = windows.weekly?.usedPercent ?? 0
-            let primaryPercent = max(sessionPercent, weeklyAllPercent)
+            let primaryPercent = [sessionPercent, weeklyPercent].compactMap { $0 }.max()
 
-            let sessionReset = windows.session?.resetAtISO
-            let weeklyReset = windows.weekly?.resetAtISO
+            // Reset detection: a large drop in the weekly figure means the
+            // window rolled over. Only meaningful when this provider actually
+            // reports a weekly window.
+            if let weeklyPercent = weeklyPercent {
+                let prevStmt = try db.prepare(
+                    "SELECT primary_percent, session_percent, weekly_all_percent, weekly_sonnet_percent, timestamp FROM usage_history WHERE account_id = ? ORDER BY timestamp DESC LIMIT 1"
+                )
+                for prev in prevStmt.bind(accountId) {
+                    let prevWeekly = (prev[2] as? Double) ?? 0
+                    if prevWeekly - weeklyPercent > 5 {
+                        let midpointDate = Date()
+                        let midpointISO = ISO8601DateFormatter().string(from: midpointDate.addingTimeInterval(-1))
 
-            // Reset detection: check previous reading
-            let prevStmt = try db.prepare(
-                "SELECT primary_percent, session_percent, weekly_all_percent, weekly_sonnet_percent, timestamp FROM usage_history WHERE account_id = ? ORDER BY timestamp DESC LIMIT 1"
-            )
-            for prev in prevStmt.bind(accountId) {
-                let prevWeekly = (prev[2] as? Double) ?? 0
-                if prevWeekly - weeklyAllPercent > 5 {
-                    let midpointDate = Date()
-                    let midpointISO = ISO8601DateFormatter().string(from: midpointDate.addingTimeInterval(-1))
+                        try db.run(
+                            "INSERT INTO usage_history (account_id, timestamp, primary_percent, session_percent, weekly_all_percent, weekly_sonnet_percent, session_reset, weekly_reset, raw_data, is_synthetic) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, 1)",
+                            accountId, midpointISO,
+                            (prev[0] as? Double) ?? 0, (prev[1] as? Double) ?? 0,
+                            prevWeekly, (prev[3] as? Double) ?? 0
+                        )
 
-                    try db.run(
-                        "INSERT INTO usage_history (account_id, timestamp, primary_percent, session_percent, weekly_all_percent, weekly_sonnet_percent, session_reset, weekly_reset, raw_data, is_synthetic) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, 1)",
-                        accountId, midpointISO,
-                        (prev[0] as? Double) ?? 0, (prev[1] as? Double) ?? 0,
-                        prevWeekly, (prev[3] as? Double) ?? 0
-                    )
-
-                    let zeroISO = ISO8601DateFormatter().string(from: midpointDate)
-                    try db.run(
-                        "INSERT INTO usage_history (account_id, timestamp, primary_percent, session_percent, weekly_all_percent, weekly_sonnet_percent, session_reset, weekly_reset, raw_data, is_synthetic) VALUES (?, ?, 0, 0, 0, 0, NULL, NULL, NULL, 1)",
-                        accountId, zeroISO
-                    )
+                        let zeroISO = ISO8601DateFormatter().string(from: midpointDate)
+                        try db.run(
+                            "INSERT INTO usage_history (account_id, timestamp, primary_percent, session_percent, weekly_all_percent, weekly_sonnet_percent, session_reset, weekly_reset, raw_data, is_synthetic) VALUES (?, ?, 0, 0, 0, 0, NULL, NULL, NULL, 1)",
+                            accountId, zeroISO
+                        )
+                    }
+                    break
                 }
-                break
             }
 
-            // Store the full captured header set (not a hand-picked subset) so the
-            // archive keeps up with new fields the API adds.
-            let rawData = headersJSON(ping.rawHeaders)
+            // Store the full captured field set (not a hand-picked subset) so
+            // the archive keeps up with new fields the provider adds.
+            let rawData = headersJSON(rawFields)
 
             try db.run("""
                 INSERT INTO usage_history (
@@ -709,17 +1003,17 @@ class OAuthPoller: ObservableObject {
                     weekly_all_percent, weekly_sonnet_percent, session_reset, weekly_reset, raw_data, is_synthetic
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
             """, accountId, now, primaryPercent, sessionPercent,
-               weeklyAllPercent, 0.0, sessionReset, weeklyReset, rawData)
+               weeklyPercent, 0.0, sessionReset, weeklyReset, rawData)
 
             try db.run("UPDATE accounts SET last_updated = ? WHERE id = ?", now, accountId)
 
         } catch {
-            flog.error("Failed to write ping to DB: \(error.localizedDescription)", category: fcat)
+            flog.error("Failed to write usage to DB: \(error.localizedDescription)", category: fcat)
         }
 
         // Archive the raw capture regardless of the curated write above.
-        archiveSnapshot(accountId: accountId, probeModel: "haiku",
-                        httpStatus: ping.httpStatus, headers: ping.rawHeaders)
+        archiveSnapshot(accountId: accountId, probeModel: probeModel,
+                        httpStatus: httpStatus, headers: rawFields)
     }
 
     // MARK: - Raw Snapshot Archive

--- a/menubar-app/ClaudeMonitor/Sources/OpenAIAPI.swift
+++ b/menubar-app/ClaudeMonitor/Sources/OpenAIAPI.swift
@@ -1,0 +1,617 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// OpenAI / ChatGPT-subscription (Codex) provider client.
+///
+/// Implements the contract live-verified in
+/// `docs/spikes/2026-07-30-codex-usage-probe.md` § "Live verification
+/// (AUTHORITATIVE)":
+///
+/// ```
+/// GET https://chatgpt.com/backend-api/wham/usage
+/// Authorization: Bearer <access_token>
+/// ```
+///
+/// Structural differences from the Anthropic client this file deliberately
+/// preserves:
+///
+/// - **Usage is a dedicated GET, not a piggybacked completion.** No inference
+///   request is burned; the same endpoint Codex CLI's own `/usage` command hits.
+/// - **Windows are named fields, not an array.** `rate_limit.primary_window` /
+///   `.secondary_window`, each with `limit_window_seconds`. The window's *kind*
+///   is derived from that duration — never from which slot it arrived in. The
+///   probe returned a **weekly** `primary_window` with a **null**
+///   `secondary_window`, so "primary = session" is provably wrong.
+/// - **Identity rides along.** `email` / `plan_type` / `account_id` come back in
+///   the same response; there is no separate profile call.
+/// - **Access tokens expire (~10 days).** `refreshCredentials` renews them via
+///   `POST https://auth.openai.com/oauth/token`; the poller calls it
+///   *proactively*, ahead of expiry, rather than reactively on a 401.
+///
+/// The `/backend-api/codex/usage` route is **not** used: it is Cloudflare
+/// bot-challenged and answers 403 with an HTML interstitial.
+///
+/// Portable core: no AppKit / SwiftUI / Combine / os.Logger — builds on Linux.
+///
+/// ## Security
+///
+/// The response body carries PII (`email`, `account_id`, `user_id`) and the
+/// request carries a live bearer token. Nothing in this file ever logs a token
+/// or a raw response body; `OpenAIUsageResponse.flatten` redacts credential and
+/// PII keys **at every level of the JSON tree**, not just the top one (the
+/// exact miss called out in spike #26's process note).
+
+private let flog = FileLogger.shared
+private let fcat = "OpenAI"
+
+// MARK: - Wire model
+
+/// Decoded `GET /backend-api/wham/usage` body. Every field is optional: this is
+/// an undocumented endpoint and a missing key must degrade, never crash.
+struct OpenAIUsageResponse: Decodable {
+    /// One rate-limit window as OpenAI reports it.
+    struct Window: Decodable {
+        let usedPercent: Double?
+        let limitWindowSeconds: Double?
+        let resetAfterSeconds: Double?
+        /// Unix epoch seconds.
+        let resetAt: Double?
+
+        /// When this window rolls over. Prefers the absolute `reset_at`; falls
+        /// back to `now + reset_after_seconds` when only the relative form came
+        /// back.
+        var resolvedResetAt: Date? {
+            if let resetAt = resetAt, resetAt > 0 { return Date(timeIntervalSince1970: resetAt) }
+            if let after = resetAfterSeconds, after > 0 { return Date().addingTimeInterval(after) }
+            return nil
+        }
+
+        /// This window in the shared model, or nil when the provider gave no
+        /// usage figure (a window we know nothing about must not read as 0%).
+        func asRateLimitWindow(status: String?) -> RateLimitWindow? {
+            guard let usedPercent = usedPercent else { return nil }
+            return RateLimitWindow(
+                usedPercent: usedPercent,
+                durationSeconds: limitWindowSeconds,
+                resetAt: resolvedResetAt,
+                status: status
+            )
+        }
+    }
+
+    struct RateLimit: Decodable {
+        let allowed: Bool?
+        let limitReached: Bool?
+        let primaryWindow: Window?
+        let secondaryWindow: Window?
+
+        /// `allowed` / `limit_reached` expressed in the same vocabulary
+        /// Anthropic's `-status` headers use, so downstream status mapping
+        /// (`RankingExporter.mapStatus`) is provider-agnostic.
+        var statusString: String {
+            if limitReached == true || allowed == false { return "rejected" }
+            return "allowed"
+        }
+
+        /// Both windows, unordered. Callers file them by duration.
+        var windows: [RateLimitWindow] {
+            let status = statusString
+            return [primaryWindow, secondaryWindow]
+                .compactMap { $0 }
+                .compactMap { $0.asRateLimitWindow(status: status) }
+        }
+    }
+
+    /// A named per-model / per-feature sub-limit, e.g.
+    /// `{"limit_name": "GPT-5.3-Codex-Spark", "metered_feature": "codex_bengalfox"}`.
+    struct AdditionalRateLimit: Decodable {
+        let limitName: String?
+        let meteredFeature: String?
+        let rateLimit: RateLimit?
+
+        /// Stable key for the `named` sub-limit map.
+        var key: String? {
+            for candidate in [limitName, meteredFeature] {
+                if let candidate = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !candidate.isEmpty {
+                    return candidate
+                }
+            }
+            return nil
+        }
+    }
+
+    let userId: String?
+    let accountId: String?
+    let email: String?
+    let planType: String?
+    let rateLimit: RateLimit?
+    let additionalRateLimits: [AdditionalRateLimit]?
+
+    // MARK: Mapping to the shared model
+
+    /// This response in the provider-agnostic window model.
+    ///
+    /// Windows are filed by **duration**, so a weekly `primary_window` lands in
+    /// `weekly` and a null `secondary_window` simply leaves `session` nil —
+    /// never a fabricated 0% session figure.
+    var rateLimitSnapshot: RateLimitSnapshot {
+        var named: [String: RateLimitWindow] = [:]
+        for entry in additionalRateLimits ?? [] {
+            guard let key = entry.key,
+                  let limit = entry.rateLimit,
+                  let window = limit.windows.max(by: { $0.usedPercent < $1.usedPercent })
+            else { continue }
+            named[key] = window
+        }
+        return RateLimitSnapshot(
+            windows: rateLimit?.windows ?? [],
+            named: named,
+            overallStatus: rateLimit?.statusString
+        )
+    }
+
+    /// Decode a `/wham/usage` body. Snake-case keys map onto the camelCase
+    /// properties above (`limit_window_seconds` → `limitWindowSeconds`).
+    static func decode(_ data: Data) throws -> OpenAIUsageResponse {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(OpenAIUsageResponse.self, from: data)
+    }
+
+    // MARK: Raw-field capture (moving-target archive, PII-redacted)
+
+    /// Keys whose **values** are never stored or logged, matched at every depth
+    /// of the JSON tree. Credentials plus the PII the endpoint volunteers.
+    ///
+    /// The account's email *is* persisted — to `accounts.email`, the documented
+    /// join key — but it is deliberately kept out of this verbatim archive,
+    /// which is dumped into logs and `probe_snapshots` far more freely.
+    static let redactedKeys: Set<String> = [
+        "access_token", "refresh_token", "id_token", "token", "api_key",
+        "email", "account_id", "user_id", "id", "name", "given_name",
+        "family_name", "picture", "phone_number", "sub",
+    ]
+
+    /// Upper bound on archived entries, so a response that grows an enormous
+    /// array can't bloat every `usage_history` row.
+    static let maxFlattenedFields = 200
+
+    /// Flatten the raw JSON body into the `[String: String]` archive shape the
+    /// rest of the app stores (mirroring Anthropic's header map), redacting
+    /// every key in `redactedKeys` at any nesting depth.
+    ///
+    /// "Capture wide, interpret narrow": fields OpenAI adds later are archived
+    /// even before this app understands them.
+    static func flatten(_ data: Data) -> [String: String] {
+        // Decoded through `JSONValue` rather than `JSONSerialization` so booleans
+        // stay distinguishable from 0/1 without CoreFoundation type checks,
+        // which don't exist on Linux.
+        guard let root = try? JSONDecoder().decode(JSONValue.self, from: data) else { return [:] }
+        var out: [String: String] = [:]
+        flattenValue(root, prefix: "", into: &out)
+        return out
+    }
+
+    private static func flattenValue(_ value: JSONValue, prefix: String, into out: inout [String: String]) {
+        guard out.count < maxFlattenedFields else { return }
+        switch value {
+        case .object(let dict):
+            for (key, child) in dict {
+                let path = prefix.isEmpty ? key : "\(prefix).\(key)"
+                if redactedKeys.contains(key.lowercased()) {
+                    out[path] = "[redacted]"
+                } else {
+                    flattenValue(child, prefix: path, into: &out)
+                }
+                if out.count >= maxFlattenedFields { return }
+            }
+        case .array(let items):
+            for (index, child) in items.enumerated() {
+                flattenValue(child, prefix: "\(prefix).\(index)", into: &out)
+                if out.count >= maxFlattenedFields { return }
+            }
+        case .null:
+            out[prefix] = "null"
+        case .bool(let flag):
+            out[prefix] = flag ? "true" : "false"
+        case .number(let number):
+            // Render whole numbers without a decimal tail, so
+            // `limit_window_seconds` archives as "604800", not "604800.0".
+            out[prefix] = (number == number.rounded() && abs(number) < 1e15)
+                ? "\(Int64(number))"
+                : "\(number)"
+        case .string(let string):
+            out[prefix] = string
+        }
+    }
+}
+
+/// A fully-general JSON value, used only to walk an arbitrary response body for
+/// archiving. `JSONDecoder` keeps booleans and numbers distinct here, which
+/// `JSONSerialization` does not do portably (on Darwin both arrive as
+/// `NSNumber` and telling them apart needs CoreFoundation, which Linux lacks).
+indirect enum JSONValue: Decodable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container, debugDescription: "Unsupported JSON value"
+            )
+        }
+    }
+}
+
+// MARK: - Refresh-token response
+
+/// `POST https://auth.openai.com/oauth/token` reply.
+struct OpenAITokenRefreshResponse: Decodable {
+    let accessToken: String?
+    let refreshToken: String?
+    let idToken: String?
+    /// Lifetime of the new access token in seconds, when stated.
+    let expiresIn: Double?
+
+    static func decode(_ data: Data) throws -> OpenAITokenRefreshResponse {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(OpenAITokenRefreshResponse.self, from: data)
+    }
+}
+
+// MARK: - API client
+
+final class OpenAIAPIClient {
+    /// The live-verified usage endpoint. The `/backend-api/codex/usage` variant
+    /// is Cloudflare-challenged (403) and must not be used.
+    static let usageURL = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
+    /// Refresh endpoint, confirmed from Codex CLI's own login log.
+    static let tokenURL = URL(string: "https://auth.openai.com/oauth/token")!
+    /// Codex CLI's public OAuth client id — a public identifier, not a secret.
+    static let oauthClientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+    static let oauthScope = "openid profile email"
+
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    // MARK: Usage
+
+    /// `GET /backend-api/wham/usage`. Read-only; no completion quota is spent.
+    func fetchUsage(accessToken: String) async throws -> ProviderUsageSnapshot {
+        var request = URLRequest(url: Self.usageURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        // No `chatgpt-account-id` header: the bearer token carries identity
+        // (verified — the probe succeeded without it).
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            flog.error("Network error fetching OpenAI usage: \(error.localizedDescription)", category: fcat)
+            throw ProviderAPIError.networkError(error)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw ProviderAPIError.invalidResponse
+        }
+
+        if http.statusCode == 401 || http.statusCode == 403 {
+            // 403 here is either a revoked token or the Cloudflare interstitial
+            // the `/codex/` route returns; both mean "this credential can't read
+            // usage right now", which is the unauthorized path.
+            flog.warning("OpenAI usage returned \(http.statusCode) — token expired, revoked, or challenged", category: fcat)
+            throw ProviderAPIError.unauthorized
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            flog.warning("Unexpected HTTP \(http.statusCode) from OpenAI usage", category: fcat)
+            throw ProviderAPIError.httpError(http.statusCode)
+        }
+
+        return try Self.snapshot(from: data, httpStatus: http.statusCode)
+    }
+
+    /// Map a raw `/wham/usage` body onto the shared snapshot type. Split out
+    /// from the network call so the self-test can exercise it against a
+    /// recorded fixture with no network and no credentials.
+    static func snapshot(from data: Data, httpStatus: Int) throws -> ProviderUsageSnapshot {
+        let decoded: OpenAIUsageResponse
+        do {
+            decoded = try OpenAIUsageResponse.decode(data)
+        } catch {
+            // Never log the body — it carries PII.
+            flog.error("Could not decode OpenAI usage response (\(data.count) bytes)", category: fcat)
+            throw ProviderAPIError.invalidResponse
+        }
+
+        guard let accountKey = decoded.accountId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !accountKey.isEmpty else {
+            flog.error("OpenAI usage response carried no account_id", category: fcat)
+            throw ProviderAPIError.invalidResponse
+        }
+
+        let snapshot = decoded.rateLimitSnapshot
+        var rawFields = OpenAIUsageResponse.flatten(data)
+        // Normalized status keys, in the compact form `RankingExporter`
+        // already parses out of `usage_history.raw_data`. Additive: the
+        // verbatim `rate_limit.*` paths are archived alongside them. Assigning
+        // nil simply omits the key — an absent window contributes no status.
+        rawFields["overall_status"] = snapshot.overallStatus
+        rawFields["session_status"] = snapshot.session?.status
+        rawFields["weekly_status"] = snapshot.weekly?.status
+
+        let session = snapshot.session.map { String(format: "%.0f%%", $0.usedPercent) } ?? "—"
+        let weekly = snapshot.weekly.map { String(format: "%.0f%%", $0.usedPercent) } ?? "—"
+        flog.info(
+            "OpenAI usage \(httpStatus) — account: \(accountKey.prefix(8))... session: \(session), weekly: \(weekly) (\(snapshot.overallStatus ?? "?"))",
+            category: fcat
+        )
+
+        return ProviderUsageSnapshot(
+            provider: .openai,
+            accountKey: accountKey,
+            httpStatus: httpStatus,
+            rateLimit: snapshot,
+            email: decoded.email,
+            plan: decoded.planType,
+            rawFields: rawFields
+        )
+    }
+
+    // MARK: Token refresh
+
+    /// Renew an access token with the stored refresh token.
+    ///
+    /// Returns nil when there is nothing to refresh (no refresh token stored) so
+    /// callers keep using the current credential; throws when the endpoint
+    /// rejects the exchange, which is the loud-failure path the poller turns
+    /// into a visible token-health state.
+    ///
+    /// OpenAI rotates refresh tokens: the reply may carry a *new* `refresh_token`
+    /// that must replace the stored one, so the result is always persisted whole
+    /// rather than merged field-by-field.
+    func refresh(_ credentials: ProviderCredentials) async throws -> ProviderCredentials? {
+        guard let refreshToken = credentials.refreshToken, !refreshToken.isEmpty else {
+            return nil
+        }
+
+        var request = URLRequest(url: Self.tokenURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let body: [String: String] = [
+            "client_id": Self.oauthClientID,
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "scope": Self.oauthScope,
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            flog.error("Network error refreshing OpenAI token: \(error.localizedDescription)", category: fcat)
+            throw ProviderAPIError.networkError(error)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw ProviderAPIError.invalidResponse
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            // Log only the OAuth error *code*, never the body (it echoes the
+            // request, refresh token included).
+            let code = Self.oauthErrorCode(data) ?? "http_\(http.statusCode)"
+            flog.error("OpenAI token refresh rejected (\(http.statusCode)/\(code))", category: fcat)
+            throw http.statusCode == 400 || http.statusCode == 401
+                ? ProviderAPIError.unauthorized
+                : ProviderAPIError.httpError(http.statusCode)
+        }
+
+        let decoded: OpenAITokenRefreshResponse
+        do {
+            decoded = try OpenAITokenRefreshResponse.decode(data)
+        } catch {
+            flog.error("Could not decode OpenAI token refresh response", category: fcat)
+            throw ProviderAPIError.invalidResponse
+        }
+
+        guard let accessToken = decoded.accessToken, !accessToken.isEmpty else {
+            flog.error("OpenAI token refresh returned no access_token", category: fcat)
+            throw ProviderAPIError.invalidResponse
+        }
+
+        // Prefer the stated lifetime; fall back to the token's own `exp` claim,
+        // which is what `~/.codex/auth.json` gives us on import.
+        let expiresAt = decoded.expiresIn.map { Date().addingTimeInterval($0) }
+            ?? Self.accessTokenExpiry(accessToken)
+
+        flog.info(
+            "Refreshed OpenAI access token (expires \(expiresAt.map { ISO8601DateFormatter().string(from: $0) } ?? "unknown"))",
+            category: fcat
+        )
+
+        return ProviderCredentials(
+            accessToken: accessToken,
+            // Rotation: keep the new refresh token when one came back.
+            refreshToken: decoded.refreshToken?.isEmpty == false ? decoded.refreshToken : refreshToken,
+            expiresAt: expiresAt
+        )
+    }
+
+    /// The `error` field of an OAuth error body (e.g. `invalid_grant`), or nil.
+    /// Only this short machine-readable code is ever surfaced.
+    static func oauthErrorCode(_ data: Data) -> String? {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        if let error = obj["error"] as? String, !error.isEmpty { return error }
+        if let error = obj["error"] as? [String: Any], let code = error["code"] as? String { return code }
+        return nil
+    }
+
+    // MARK: JWT expiry
+
+    /// Read the `exp` claim out of a JWT access token **without verifying it** —
+    /// we are reading an already-issued token's stated lifetime, not trusting
+    /// it for authorization.
+    ///
+    /// `~/.codex/auth.json` stores no expiry of its own, so this is how an
+    /// imported credential gets a `token_expires_at`. Only the numeric `exp`
+    /// claim is read; no other claim (all of which are PII) is decoded, logged,
+    /// or returned.
+    static func accessTokenExpiry(_ token: String) -> Date? {
+        let parts = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count >= 2, let payload = base64URLDecode(String(parts[1])) else { return nil }
+        guard let claims = try? JSONSerialization.jsonObject(with: payload) as? [String: Any] else { return nil }
+        guard let exp = claims["exp"] as? Double ?? (claims["exp"] as? NSNumber)?.doubleValue, exp > 0 else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: exp)
+    }
+
+    static func base64URLDecode(_ string: String) -> Data? {
+        var s = string.replacingOccurrences(of: "-", with: "+")
+                      .replacingOccurrences(of: "_", with: "/")
+        let remainder = s.count % 4
+        if remainder > 0 { s += String(repeating: "=", count: 4 - remainder) }
+        return Data(base64Encoded: s)
+    }
+}
+
+// MARK: - UsageProviderClient conformance
+
+extension OpenAIAPIClient: UsageProviderClient {
+    var provider: AccountProvider { .openai }
+
+    func fetchUsage(_ credentials: ProviderCredentials) async throws -> ProviderUsageSnapshot {
+        try await fetchUsage(accessToken: credentials.accessToken)
+    }
+
+    /// Identity comes back with usage, so identification is the same (free,
+    /// read-only) call rather than a separate profile fetch.
+    func identifyAccount(_ credentials: ProviderCredentials) async throws -> String {
+        try await fetchUsage(credentials).accountKey
+    }
+
+    func refreshCredentials(_ credentials: ProviderCredentials) async throws -> ProviderCredentials? {
+        try await refresh(credentials)
+    }
+}
+
+// MARK: - Codex credential import
+
+/// Reads Codex CLI's ChatGPT-OAuth credential store, `~/.codex/auth.json`
+/// (or `$CODEX_HOME/auth.json`) — the practical way to get an OpenAI
+/// credential into this app, mirroring how bulk import reads `accounts.env`.
+///
+/// Nothing here logs or returns a token value beyond the caller that stores it.
+enum CodexAuth {
+    /// Codex CLI's credential path, honoring `$CODEX_HOME`.
+    ///
+    /// Note `FileManager.homeDirectoryForCurrentUser` ignores a `HOME`
+    /// override on macOS, so tests must pass an explicit scratch path rather
+    /// than relying on an environment override (issue #16).
+    static var defaultAuthPath: String {
+        let env = ProcessInfo.processInfo.environment["CODEX_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let env = env, !env.isEmpty {
+            return (env as NSString).appendingPathComponent("auth.json")
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/auth.json").path
+    }
+
+    struct Credential {
+        let accessToken: String
+        let refreshToken: String?
+        let accountId: String?
+        let expiresAt: Date?
+    }
+
+    enum ImportError: Error, LocalizedError {
+        case notFound(String)
+        case unreadable(String)
+        case malformed
+        case noAccessToken
+
+        var errorDescription: String? {
+            switch self {
+            case .notFound(let path):
+                return "No Codex credential at \(path) — run `codex login` first, or pass --auth <path>"
+            case .unreadable(let path):
+                return "Could not read \(path)"
+            case .malformed:
+                return "Not a Codex auth.json (expected a `tokens` object)"
+            case .noAccessToken:
+                return "Codex auth.json has no access_token"
+            }
+        }
+    }
+
+    /// Parse an `auth.json` body. Shape (values elided):
+    /// `{"OPENAI_API_KEY": null, "tokens": {"id_token": …, "access_token": …,
+    ///   "refresh_token": …, "account_id": …}, "last_refresh": …}`
+    static func parse(_ data: Data) throws -> Credential {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ImportError.malformed
+        }
+        guard let tokens = root["tokens"] as? [String: Any] else {
+            throw ImportError.malformed
+        }
+        guard let accessToken = (tokens["access_token"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              !accessToken.isEmpty else {
+            throw ImportError.noAccessToken
+        }
+        let refreshToken = (tokens["refresh_token"] as? String)
+            .flatMap { $0.isEmpty ? nil : $0 }
+        let accountId = (tokens["account_id"] as? String)
+            .flatMap { $0.isEmpty ? nil : $0 }
+        return Credential(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            accountId: accountId,
+            // auth.json states no expiry; the access token's own `exp` claim does.
+            expiresAt: OpenAIAPIClient.accessTokenExpiry(accessToken)
+        )
+    }
+
+    /// Load and parse a credential file. `path` defaults to `defaultAuthPath`.
+    static func load(path: String? = nil) throws -> Credential {
+        let path = path ?? defaultAuthPath
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw ImportError.notFound(path)
+        }
+        guard let data = FileManager.default.contents(atPath: path) else {
+            throw ImportError.unreadable(path)
+        }
+        return try parse(data)
+    }
+}

--- a/menubar-app/ClaudeMonitor/Sources/RankingExporter.swift
+++ b/menubar-app/ClaudeMonitor/Sources/RankingExporter.swift
@@ -24,6 +24,7 @@ import Foundation
 ///   "accounts": [
 ///     {
 ///       "email": "user@example.com",
+///       "provider": "anthropic",
 ///       "plan": "max_20x",
 ///       "status": "available",
 ///       "utilization": { "5h": 0.12, "7d": 0.44 },
@@ -34,18 +35,32 @@ import Foundation
 ///   ]
 /// }
 /// ```
+///
+/// ### `provider` (added in epic #25 phase 3)
+///
+/// `provider` is `"anthropic"` or `"openai"` and is **additive within schema 1**:
+/// the version number tracks *breaking* changes, and adding an optional key
+/// breaks nobody. A consumer that ignores it behaves exactly as before (every
+/// account predating multi-provider support reports `"anthropic"`); a consumer
+/// that reads it can route work to the right upstream. Unknown future values
+/// should be treated as "some other provider", never rejected.
+///
+/// **A `provider: "openai"` account may legitimately omit `utilization["5h"]`**
+/// — the live-verified Codex usage endpoint can report a weekly window and no
+/// session window at all. Consumers must treat a missing key as *unknown*, not
+/// as 0.0 (which would read as "full session capacity available").
 enum RankingExporter {
     static let schemaVersion = 1
 
     /// Serializes exports so overlapping poll cycles never race on the write.
     private static let queue = DispatchQueue(label: "com.claude-monitor.ranking-exporter")
 
-    private static var dbPath: String {
+    static var defaultDBPath: String {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".claude-monitor/usage.db").path
     }
 
-    private static var outputPath: String {
+    static var defaultOutputPath: String {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".claude-monitor/ranking.json").path
     }
@@ -60,6 +75,14 @@ enum RankingExporter {
     /// --once run can't exit before ranking.json lands on disk.
     static func exportNow() {
         queue.sync { exportSync() }
+    }
+
+    /// Export a specific database to a specific path, synchronously. Both paths
+    /// are **explicit** — the self-test uses this against a scratch directory
+    /// rather than a `HOME` override, which `homeDirectoryForCurrentUser`
+    /// ignores on macOS (issue #16).
+    static func exportNow(dbPath: String, outputPath: String) {
+        queue.sync { exportSync(dbPath: dbPath, outputPath: outputPath) }
     }
 
     // MARK: - Status mapping
@@ -91,7 +114,10 @@ enum RankingExporter {
 
     // MARK: - Export implementation
 
-    private static func exportSync() {
+    private static func exportSync(
+        dbPath: String = defaultDBPath,
+        outputPath: String = defaultOutputPath
+    ) {
         guard FileManager.default.fileExists(atPath: dbPath) else { return }
 
         do {
@@ -100,9 +126,14 @@ enum RankingExporter {
             var accountObjects: [[String: Any]] = []
 
             // Only non-secret columns are read. `accounts` carries no tokens.
-            let accountStmt = try db.prepare(
-                "SELECT id, email, plan FROM accounts ORDER BY sort_order ASC, last_updated DESC"
-            )
+            // `provider` is selected only when the column exists, so an
+            // unmigrated database still exports (every row then resolves to the
+            // Anthropic fallback).
+            let hasProvider = tableColumns(db, "accounts").contains("provider")
+            let accountStmt = try db.prepare("""
+                SELECT id, email, plan\(hasProvider ? ", provider" : "")
+                FROM accounts ORDER BY sort_order ASC, last_updated DESC
+            """)
 
             for row in accountStmt {
                 guard let accountId = row[0] as? String else { continue }
@@ -110,8 +141,10 @@ enum RankingExporter {
                 // (email is the sole join key — a null key is useless to consumers).
                 guard let email = row[1] as? String, !email.isEmpty else { continue }
                 let plan = row[2] as? String
+                let provider = AccountProvider(stored: hasProvider ? row[3] as? String : nil)
 
-                if let obj = buildAccount(db: db, accountId: accountId, email: email, plan: plan) {
+                if let obj = buildAccount(db: db, accountId: accountId, email: email,
+                                          plan: plan, provider: provider) {
                     accountObjects.append(obj)
                 }
             }
@@ -144,9 +177,13 @@ enum RankingExporter {
         db: Connection,
         accountId: String,
         email: String,
-        plan: String?
+        plan: String?,
+        provider: AccountProvider
     ) -> [String: Any]? {
-        var obj: [String: Any] = ["email": email]
+        // `provider` is emitted unconditionally (never omitted) so a consumer
+        // can rely on its presence rather than defaulting per-account; rows that
+        // predate multi-provider support resolve to "anthropic".
+        var obj: [String: Any] = ["email": email, "provider": provider.rawValue]
         if let plan = plan { obj["plan"] = plan }
 
         // Latest real (non-synthetic) usage reading for this account.

--- a/menubar-app/ClaudeMonitor/Sources/RateLimitWindow.swift
+++ b/menubar-app/ClaudeMonitor/Sources/RateLimitWindow.swift
@@ -49,6 +49,16 @@ enum AccountProvider: String, CaseIterable, Codable {
         case .openai: return "OpenAI"
         }
     }
+
+    /// Two-letter badge shown in the popover's account column, where there is
+    /// no room for the full name. Lives here (portable core) rather than in the
+    /// macOS view so the headless daemon's log lines can use the same code.
+    var shortCode: String {
+        switch self {
+        case .anthropic: return "AN"
+        case .openai: return "OA"
+        }
+    }
 }
 
 // MARK: - Window kind

--- a/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
+++ b/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
@@ -18,7 +18,7 @@ enum SelfTest {
 
         if arguments.contains("--help") || arguments.contains("-h") {
             print("""
-                Usage: ClaudeMonitor selftest [--db <path>]
+                Usage: ClaudeMonitor selftest [--db <path>] [--wire <path>]
 
                 Runs assertions over the portable core (rate-limit window model,
                 schema migration). No network access and no credentials needed.
@@ -26,6 +26,13 @@ enum SelfTest {
                   --db <path>   Additionally migrate an existing database *copy*
                                 and verify its accounts still load. Point this at
                                 a COPY of ~/.claude-monitor/usage.db — it writes.
+
+                  --wire <path> Additionally decode a captured OpenAI
+                                `GET /backend-api/wham/usage` body and report the
+                                windows it maps to — the offline way to re-check
+                                the wire contract after OpenAI changes it. Only
+                                derived numbers are printed; identity fields are
+                                never echoed.
 
                 Exits 0 when every check passes, 1 otherwise.
                 """)
@@ -36,10 +43,19 @@ enum SelfTest {
         testSnapshotFromPositionalWindows()
         testMissingSessionWindow()
         testProviderParsing()
+        testOpenAIUsageResponseMapping()
+        testOpenAIRawFieldRedaction()
+        testOpenAITokenExpiryParsing()
+        testCodexAuthParsing()
         testSchemaMigrationFromPreMigrationDatabase()
+        testRankingExportCarriesProvider()
 
         if let idx = arguments.firstIndex(of: "--db"), idx + 1 < arguments.count {
             testMigrationOfExistingDatabase(at: arguments[idx + 1])
+        }
+
+        if let idx = arguments.firstIndex(of: "--wire"), idx + 1 < arguments.count {
+            testCapturedOpenAIWireBody(at: arguments[idx + 1])
         }
 
         if failures.isEmpty {
@@ -154,6 +170,267 @@ enum SelfTest {
         expectEqual(AccountProvider(stored: "  OpenAI "), .openai, "provider parse is trimmed + case-insensitive")
         expectEqual(AccountProvider(stored: "martian"), .anthropic, "unknown provider → anthropic fallback")
         expectEqual(AccountProvider(stored: "openai").rawValue, "openai", "round-trips through rawValue")
+    }
+
+    // MARK: - OpenAI / Codex
+
+    /// A recorded `GET /backend-api/wham/usage` body in the exact shape the
+    /// live probe returned (spike #26 § "Live verification"), with every
+    /// identity value replaced by a fixture string. Deliberately includes the
+    /// two findings that broke the static-analysis hypothesis: a **weekly**
+    /// `primary_window` and a **null** `secondary_window`.
+    private static let openAIUsageFixture = """
+    {
+      "user_id": "user-fixture",
+      "account_id": "acct-fixture",
+      "email": "fixture@example.com",
+      "plan_type": "pro",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window": {
+          "used_percent": 14,
+          "limit_window_seconds": 604800,
+          "reset_after_seconds": 524971,
+          "reset_at": 1785967226
+        },
+        "secondary_window": null
+      },
+      "code_review_rate_limit": null,
+      "additional_rate_limits": [
+        {
+          "limit_name": "GPT-5.3-Codex-Spark",
+          "metered_feature": "codex_bengalfox",
+          "rate_limit": {
+            "allowed": true,
+            "limit_reached": false,
+            "primary_window": {
+              "used_percent": 62,
+              "limit_window_seconds": 604800,
+              "reset_after_seconds": 100,
+              "reset_at": 1785967226
+            },
+            "secondary_window": null
+          }
+        }
+      ]
+    }
+    """
+
+    /// The wire contract, mapped onto the shared model: windows filed by
+    /// duration, a null secondary window left nil, identity picked up from the
+    /// same response, and per-model sub-limits landing in `named`.
+    private static func testOpenAIUsageResponseMapping() {
+        do {
+            let snapshot = try OpenAIAPIClient.snapshot(
+                from: Data(openAIUsageFixture.utf8), httpStatus: 200
+            )
+
+            expectEqual(snapshot.provider, .openai, "snapshot provider")
+            expectEqual(snapshot.accountKey, "acct-fixture", "account key from account_id")
+            expectEqual(snapshot.email, "fixture@example.com", "identity arrives with usage")
+            expectEqual(snapshot.plan, "pro", "plan_type arrives with usage")
+
+            let windows = snapshot.rateLimit
+            expect(windows.session == nil,
+                   "a null secondary_window must leave session nil, never a fabricated 0%")
+            expectEqual(windows.weekly?.usedPercent, 14, "weekly used_percent")
+            expectEqual(windows.weekly?.kind, .weekly,
+                        "a weekly primary_window is filed by duration, not by slot")
+            expectEqual(windows.weekly?.durationSeconds, 604800, "limit_window_seconds is seconds")
+            expectEqual(windows.weekly?.resetAt, Date(timeIntervalSince1970: 1785967226),
+                        "reset_at is unix epoch seconds")
+            expectEqual(windows.headroomScore, 86, "headroom from a weekly-only OpenAI snapshot")
+            expectEqual(windows.overallStatus, "allowed", "allowed:true maps to the shared 'allowed'")
+            expectEqual(windows.named["GPT-5.3-Codex-Spark"]?.usedPercent, 62,
+                        "additional_rate_limits land in the named sub-limit map")
+
+            // `limit_reached` is the direct "you are cut off" signal.
+            let capped = openAIUsageFixture
+                .replacingOccurrences(of: "\"limit_reached\": false", with: "\"limit_reached\": true")
+                .replacingOccurrences(of: "\"allowed\": true", with: "\"allowed\": false")
+            let cappedSnapshot = try OpenAIAPIClient.snapshot(from: Data(capped.utf8), httpStatus: 200)
+            expectEqual(cappedSnapshot.rateLimit.overallStatus, "rejected",
+                        "limit_reached maps to the shared 'rejected' status")
+            expect(cappedSnapshot.rateLimit.weekly?.isExhausted == true,
+                   "a rejected window reads as exhausted regardless of percent")
+
+            // A response with no account_id is unusable — fail rather than
+            // inventing a key that would collide across accounts.
+            let anonymous = openAIUsageFixture
+                .replacingOccurrences(of: "\"account_id\": \"acct-fixture\"", with: "\"account_id\": null")
+            var threw = false
+            do {
+                _ = try OpenAIAPIClient.snapshot(from: Data(anonymous.utf8), httpStatus: 200)
+            } catch {
+                threw = true
+            }
+            expect(threw, "a response without account_id must throw, not fabricate a key")
+
+            // A session window arriving in either slot still files as session.
+            let withSession = openAIUsageFixture.replacingOccurrences(
+                of: "\"secondary_window\": null",
+                with: """
+                "secondary_window": {"used_percent": 30, "limit_window_seconds": 18000, "reset_at": 1785900000}
+                """
+            )
+            let paired = try OpenAIAPIClient.snapshot(from: Data(withSession.utf8), httpStatus: 200)
+            expectEqual(paired.rateLimit.session?.usedPercent, 30, "session filed from the secondary slot")
+            expectEqual(paired.rateLimit.weekly?.usedPercent, 14, "weekly stays in weekly")
+            expectEqual(paired.rateLimit.headroomScore, 70, "headroom uses the most-consumed window")
+        } catch {
+            checks += 1
+            failures.append("OpenAI usage mapping threw: \(error)")
+        }
+    }
+
+    /// The archive must capture the response's *shape* without its secrets. The
+    /// #26 near-miss was a **nested** identity claim surviving a top-level-only
+    /// redaction pass, so this asserts on nesting explicitly.
+    private static func testOpenAIRawFieldRedaction() {
+        do {
+            let snapshot = try OpenAIAPIClient.snapshot(
+                from: Data(openAIUsageFixture.utf8), httpStatus: 200
+            )
+            let archived = snapshot.rawFields
+            let serialized = archived.map { "\($0.key)=\($0.value)" }.joined(separator: "\n")
+
+            expect(!serialized.contains("fixture@example.com"), "email must never reach the archive")
+            expect(!serialized.contains("acct-fixture"), "account_id must never reach the archive")
+            expect(!serialized.contains("user-fixture"), "user_id must never reach the archive")
+            expectEqual(archived["email"], "[redacted]", "redacted keys are recorded as present")
+
+            // Nested PII: a profile object buried two levels down must be
+            // redacted just like a top-level key.
+            let nested = """
+            {"account_id":"acct-fixture","rate_limit":{"allowed":true,"primary_window":
+             {"used_percent":1,"limit_window_seconds":604800}},
+             "profile":{"organization":{"email":"nested@example.com","name":"Nested Person"}}}
+            """
+            let nestedSnapshot = try OpenAIAPIClient.snapshot(from: Data(nested.utf8), httpStatus: 200)
+            let nestedSerialized = nestedSnapshot.rawFields
+                .map { "\($0.key)=\($0.value)" }.joined(separator: "\n")
+            expect(!nestedSerialized.contains("nested@example.com"),
+                   "a nested email claim must be redacted (the #26 near-miss)")
+            expect(!nestedSerialized.contains("Nested Person"),
+                   "a nested name claim must be redacted")
+            expectEqual(nestedSnapshot.rawFields["profile.organization.email"], "[redacted]",
+                        "nested redaction records the path")
+
+            // Non-PII fields are still archived verbatim, so a field OpenAI adds
+            // later is captured before we interpret it.
+            expectEqual(archived["rate_limit.primary_window.limit_window_seconds"], "604800",
+                        "verbatim wire fields are archived")
+            expectEqual(archived["overall_status"], "allowed",
+                        "normalized status keys are archived for RankingExporter")
+        } catch {
+            checks += 1
+            failures.append("OpenAI redaction test threw: \(error)")
+        }
+    }
+
+    /// OpenAI access tokens expire (~10 days) and `auth.json` states no expiry,
+    /// so the token's own `exp` claim is the only source. Only `exp` is read.
+    private static func testOpenAITokenExpiryParsing() {
+        func b64url(_ json: String) -> String {
+            Data(json.utf8).base64EncodedString()
+                .replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "=", with: "")
+        }
+        // A structurally-valid but entirely synthetic JWT — no real credential.
+        let token = "\(b64url("{\"alg\":\"RS256\"}")).\(b64url("{\"exp\":1785967226,\"sub\":\"fixture\"}")).sig"
+        expectEqual(OpenAIAPIClient.accessTokenExpiry(token),
+                    Date(timeIntervalSince1970: 1785967226), "exp claim decodes to a Date")
+        expect(OpenAIAPIClient.accessTokenExpiry("not-a-jwt") == nil, "a non-JWT yields nil, not a crash")
+        expect(OpenAIAPIClient.accessTokenExpiry("") == nil, "an empty token yields nil")
+        expect(OpenAIAPIClient.accessTokenExpiry("\(b64url("{}")).\(b64url("{\"sub\":\"x\"}")).sig") == nil,
+               "a JWT without exp yields nil")
+
+        // Expiry drives proactive renewal, and an Anthropic credential (no
+        // stated expiry) must never report as expiring.
+        let expiring = ProviderCredentials(accessToken: "x", refreshToken: "rt",
+                                           expiresAt: Date().addingTimeInterval(600))
+        expect(expiring.isExpiring(within: 3600), "a token expiring in 10 min is expiring")
+        expect(expiring.isRefreshable, "a stored refresh token makes it refreshable")
+        let anthropic = ProviderCredentials(accessToken: "sk-ant-oat01-x")
+        expect(!anthropic.isExpiring(within: 3600), "no stated expiry never reports as expiring")
+        expect(!anthropic.isRefreshable, "no refresh token means not refreshable")
+
+        // OAuth error bodies surface only their machine-readable code. Both the
+        // flat RFC 6749 form and the nested form `auth.openai.com` actually
+        // returns (verified live with a deliberately-invalid refresh token)
+        // are handled.
+        expectEqual(OpenAIAPIClient.oauthErrorCode(Data("{\"error\":\"invalid_grant\"}".utf8)),
+                    "invalid_grant", "flat OAuth error code is extracted")
+        expectEqual(
+            OpenAIAPIClient.oauthErrorCode(Data("""
+            {"error":{"message":"Invalid refresh token.","type":"invalid_request_error",
+                      "param":null,"code":"invalid_refresh_token"}}
+            """.utf8)),
+            "invalid_refresh_token",
+            "the nested error shape auth.openai.com returns is extracted"
+        )
+        expect(OpenAIAPIClient.oauthErrorCode(Data("not json".utf8)) == nil,
+               "a non-JSON error body yields nil")
+    }
+
+    /// Codex CLI's `auth.json`, parsed from an explicit scratch path — never a
+    /// `$HOME`-relative default, which `homeDirectoryForCurrentUser` would
+    /// resolve to the real credential store regardless of a `HOME` override
+    /// (issue #16).
+    private static func testCodexAuthParsing() {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("claude-monitor-selftest-codex-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let authPath = dir.appendingPathComponent("auth.json").path
+
+            func b64url(_ json: String) -> String {
+                Data(json.utf8).base64EncodedString()
+                    .replacingOccurrences(of: "+", with: "-")
+                    .replacingOccurrences(of: "/", with: "_")
+                    .replacingOccurrences(of: "=", with: "")
+            }
+            let fakeAccess = "\(b64url("{\"alg\":\"none\"}")).\(b64url("{\"exp\":1785967226}")).sig"
+            let fixture = """
+            {"OPENAI_API_KEY": null,
+             "tokens": {"id_token": "fixture-id", "access_token": "\(fakeAccess)",
+                        "refresh_token": "rt.fixture", "account_id": "acct-fixture"},
+             "last_refresh": "2026-07-30T00:00:00Z"}
+            """
+            try Data(fixture.utf8).write(to: URL(fileURLWithPath: authPath))
+
+            let credential = try CodexAuth.load(path: authPath)
+            expectEqual(credential.accessToken, fakeAccess, "access_token read from tokens{}")
+            expectEqual(credential.refreshToken, "rt.fixture", "refresh_token read from tokens{}")
+            expectEqual(credential.accountId, "acct-fixture", "account_id read from tokens{}")
+            expectEqual(credential.expiresAt, Date(timeIntervalSince1970: 1785967226),
+                        "expiry derived from the access token's exp claim")
+
+            // A file that isn't a Codex credential fails cleanly.
+            let bogusPath = dir.appendingPathComponent("bogus.json").path
+            try Data("{\"hello\":\"world\"}".utf8).write(to: URL(fileURLWithPath: bogusPath))
+            var threw = false
+            do { _ = try CodexAuth.load(path: bogusPath) } catch { threw = true }
+            expect(threw, "a file with no tokens{} object is rejected")
+
+            // A missing file reports the path rather than crashing.
+            threw = false
+            do {
+                _ = try CodexAuth.load(path: dir.appendingPathComponent("absent.json").path)
+            } catch { threw = true }
+            expect(threw, "a missing auth.json is an error, not a crash")
+
+            // $CODEX_HOME resolution is pure string work — assert the shape
+            // without mutating this process's environment.
+            expect(CodexAuth.defaultAuthPath.hasSuffix("auth.json"),
+                   "default Codex credential path ends in auth.json")
+        } catch {
+            checks += 1
+            failures.append("Codex auth parsing test threw: \(error)")
+        }
     }
 
     // MARK: - Schema migration
@@ -280,6 +557,150 @@ enum SelfTest {
         } catch {
             checks += 1
             failures.append("schema migration test threw: \(error)")
+        }
+    }
+
+    /// Decode a captured `/backend-api/wham/usage` body and report what the
+    /// shared model made of it. This is the offline half of live verification:
+    /// capture the body once (`curl -H "Authorization: Bearer …"`), then re-run
+    /// this whenever the client changes, with no credential in the loop.
+    ///
+    /// **Only derived numbers are printed.** The account key is truncated and
+    /// the email is reported as present/absent, never echoed — the same
+    /// discipline `OpenAIUsageResponse.flatten` applies to the archive.
+    private static func testCapturedOpenAIWireBody(at path: String) {
+        guard let data = FileManager.default.contents(atPath: path) else {
+            checks += 1
+            failures.append("--wire: could not read \(path)")
+            return
+        }
+        do {
+            let snapshot = try OpenAIAPIClient.snapshot(from: data, httpStatus: 200)
+            let windows = snapshot.rateLimit
+
+            expect(!snapshot.accountKey.isEmpty, "--wire: response carried an account key")
+            expect(!windows.isEmpty, "--wire: response carried at least one rate-limit window")
+            expect(windows.session == nil || windows.session?.kind == .session,
+                   "--wire: the session slot holds a session-length window")
+            expect(windows.weekly == nil || windows.weekly?.kind == .weekly,
+                   "--wire: the weekly slot holds a weekly-length window")
+            let serialized = snapshot.rawFields.map { "\($0.key)=\($0.value)" }.joined(separator: "\n")
+            if let email = snapshot.email, !email.isEmpty {
+                expect(!serialized.contains(email), "--wire: the live email never reaches the archive")
+            }
+
+            func describe(_ window: RateLimitWindow?) -> String {
+                guard let window = window else { return "none" }
+                let reset = window.resetAt.map { ISO8601DateFormatter().string(from: $0) } ?? "unknown"
+                return String(format: "%.0f%% used, %.0fs window, resets %@",
+                              window.usedPercent, window.durationSeconds ?? 0, reset)
+            }
+            print("""
+                selftest --wire: \(path)
+                  account:  \(snapshot.accountKey.prefix(8))… (email \(snapshot.email?.isEmpty == false ? "present" : "absent"))
+                  plan:     \(snapshot.plan ?? "unknown")
+                  status:   \(windows.overallStatus ?? "unknown")
+                  session:  \(describe(windows.session))
+                  weekly:   \(describe(windows.weekly))
+                  headroom: \(windows.headroomScore.map { String(format: "%.0f", $0) } ?? "—")
+                  named:    \(windows.named.keys.sorted().joined(separator: ", "))
+                  archived: \(snapshot.rawFields.count) field(s), PII redacted
+                """)
+        } catch {
+            checks += 1
+            failures.append("--wire: could not map \(path) onto the shared model: \(error)")
+        }
+    }
+
+    // MARK: - ranking.json
+
+    /// `ranking.json` must carry `provider` for every account, and an OpenAI
+    /// account with no session window must omit `utilization["5h"]` rather than
+    /// report 0.0 (which a consumer would read as "full session capacity").
+    ///
+    /// Runs against an explicit scratch database *and* an explicit scratch
+    /// output path — never the `$HOME`-relative defaults.
+    private static func testRankingExportCarriesProvider() {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("claude-monitor-selftest-ranking-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let dbPath = dir.appendingPathComponent("usage.db").path
+            let outPath = dir.appendingPathComponent("ranking.json").path
+
+            UsageStore(dbPath: dbPath).ensureDatabase()
+            let db = try openDatabase(dbPath)
+            let now = ISO8601DateFormatter().string(from: Date())
+
+            try db.run("""
+                INSERT INTO accounts (id, account_name, email, plan, last_updated, sort_order, provider)
+                VALUES ('org-anthropic', 'a@example.com', 'a@example.com', 'Max', ?, 0, 'anthropic')
+            """, now)
+            try db.run("""
+                INSERT INTO accounts (id, account_name, email, plan, last_updated, sort_order, provider)
+                VALUES ('acct-openai', 'o@example.com', 'o@example.com', 'pro', ?, 1, 'openai')
+            """, now)
+            try db.run("""
+                INSERT INTO usage_history
+                    (account_id, timestamp, primary_percent, session_percent,
+                     weekly_all_percent, weekly_sonnet_percent, raw_data, is_synthetic)
+                VALUES ('org-anthropic', ?, 40, 40, 12, 0,
+                        '{"overall_status":"allowed","session_status":"allowed","weekly_status":"allowed"}', 0)
+            """, now)
+            // The OpenAI shape: NULL session_percent, because the provider
+            // reported no session window at all.
+            try db.run("""
+                INSERT INTO usage_history
+                    (account_id, timestamp, primary_percent, session_percent,
+                     weekly_all_percent, weekly_sonnet_percent, raw_data, is_synthetic)
+                VALUES ('acct-openai', ?, 14, NULL, 14, 0,
+                        '{"overall_status":"allowed","weekly_status":"allowed"}', 0)
+            """, now)
+
+            RankingExporter.exportNow(dbPath: dbPath, outputPath: outPath)
+
+            guard let data = FileManager.default.contents(atPath: outPath),
+                  let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let accounts = root["accounts"] as? [[String: Any]] else {
+                checks += 1
+                failures.append("ranking export produced no readable accounts array")
+                return
+            }
+
+            expectEqual(root["schema"] as? Int, RankingExporter.schemaVersion,
+                        "provider is additive — the schema version does not change")
+            expectEqual(accounts.count, 2, "both accounts exported")
+
+            let byEmail = Dictionary(uniqueKeysWithValues: accounts.compactMap { obj -> (String, [String: Any])? in
+                guard let email = obj["email"] as? String else { return nil }
+                return (email, obj)
+            })
+
+            expectEqual(byEmail["a@example.com"]?["provider"] as? String, "anthropic",
+                        "Anthropic account carries provider")
+            expectEqual(byEmail["o@example.com"]?["provider"] as? String, "openai",
+                        "OpenAI account carries provider")
+
+            // Every field an existing consumer already reads is unchanged.
+            expectEqual(byEmail["a@example.com"]?["status"] as? String, "available",
+                        "existing status field unaffected")
+            let anthropicUtil = byEmail["a@example.com"]?["utilization"] as? [String: Any]
+            expectEqual(anthropicUtil?["5h"] as? Double, 0.4, "Anthropic 5h utilization unchanged")
+            expectEqual(anthropicUtil?["7d"] as? Double, 0.12, "Anthropic 7d utilization unchanged")
+
+            let openaiUtil = byEmail["o@example.com"]?["utilization"] as? [String: Any]
+            expect(openaiUtil?["5h"] == nil,
+                   "a provider with no session window omits 5h rather than reporting 0.0")
+            expectEqual(openaiUtil?["7d"] as? Double, 0.14, "OpenAI weekly utilization exported")
+
+            // No secret ever reaches ranking.json.
+            let text = String(data: data, encoding: .utf8) ?? ""
+            expect(!text.contains("access_token") && !text.contains("refresh_token"),
+                   "ranking.json never carries credential material")
+        } catch {
+            checks += 1
+            failures.append("ranking export test threw: \(error)")
         }
     }
 

--- a/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
@@ -93,6 +93,37 @@ func extraUsageUrgency(_ usage: UsageRecord?) -> Double? {
 // `UsageRecord.rateLimit`, so the string-parsing helper that used to live here
 // is gone; `UsageRecord.parseISO` is the single ISO-8601 parse point.
 
+// MARK: - Provider badge
+
+/// Compact per-provider tag shown ahead of the account name, so a row's upstream
+/// is visible at a glance in a mixed Anthropic/OpenAI list. It sits inside the
+/// existing Account column rather than adding a new one, keeping every other
+/// column (and the popover width) exactly where it was.
+struct ProviderBadge: View {
+    let provider: AccountProvider
+
+    private var tint: Color {
+        switch provider {
+        case .anthropic: return Color(nsColor: .systemOrange)
+        case .openai: return Color(nsColor: .systemTeal)
+        }
+    }
+
+    var body: some View {
+        Text(provider.shortCode)
+            .font(.system(size: 8, weight: .bold, design: .rounded))
+            .foregroundColor(tint)
+            .padding(.horizontal, 3)
+            .padding(.vertical, 1)
+            .overlay(
+                RoundedRectangle(cornerRadius: 3)
+                    .stroke(tint.opacity(0.6), lineWidth: 1)
+            )
+            .help(provider.displayName)
+            .accessibilityLabel(provider.displayName)
+    }
+}
+
 /// Lower rank = "better" status (valid first, missing last).
 func tokenStatusRank(_ status: TokenStatus) -> Int {
     switch status {
@@ -425,9 +456,15 @@ struct UsagePopoverView: View {
                 // account whose email isn't in the paste (compared case-insensitively).
                 // Emails come from the paste even for entries whose token failed to
                 // import, so a transient failure won't delete an account that's listed.
+                //
+                // Scoped to Anthropic rows: the env format can only *express*
+                // Anthropic credentials (see `exportAccountsEnv`), so an
+                // Anthropic-only paste must not silently delete the OpenAI
+                // accounts it was never able to describe.
                 let pastedEmails = Set(results.map { $0.email.lowercased() })
                 let toRemove = store.accounts.filter {
-                    !pastedEmails.contains(($0.email ?? "").lowercased())
+                    $0.provider == .anthropic
+                        && !pastedEmails.contains(($0.email ?? "").lowercased())
                 }
                 for account in toRemove { removeAccount(account) }
                 if !toRemove.isEmpty { store.loadFromDatabase() }
@@ -658,13 +695,16 @@ struct SummaryRow: View {
                         .buttonStyle(.plain)
                     }
                 } else {
-                    Text(account.displayName)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
-                        .onTapGesture(count: 2) { startRename() }
-                        .help("Double-click to rename")
+                    HStack(spacing: 4) {
+                        ProviderBadge(provider: account.provider)
+                        Text(account.displayName)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) { startRename() }
+                    .help("\(account.provider.displayName) — double-click to rename")
                 }
             }
             .frame(width: SummaryColumns.account, alignment: .leading)
@@ -738,8 +778,13 @@ struct SummaryRow: View {
             Button(action: startRename) {
                 Label("Rename", systemImage: "pencil")
             }
-            Button(action: openRollToken) {
-                Label("Roll Token…", systemImage: "arrow.triangle.2.circlepath")
+            // The Roll Token wizard drives undocumented claude.ai endpoints, so
+            // it only makes sense for Anthropic rows. OpenAI credentials are
+            // refreshed automatically and re-imported with `codex import`.
+            if account.provider == .anthropic {
+                Button(action: openRollToken) {
+                    Label("Roll Token…", systemImage: "arrow.triangle.2.circlepath")
+                }
             }
             Divider()
             Button(role: .destructive, action: { onRemove?() }) {
@@ -1024,6 +1069,32 @@ struct AddAccountView: View {
                 }
             }
 
+            Divider()
+
+            // OpenAI / Codex — imported from Codex CLI's own credential store
+            // rather than pasted, because a ChatGPT OAuth credential is a
+            // three-part (access + refresh + expiry) object, not a single
+            // long-lived string.
+            VStack(alignment: .leading, spacing: 6) {
+                Text("OpenAI (Codex)")
+                    .font(.caption.bold())
+                    .foregroundColor(.secondary)
+                Text("Imports the credential `codex login` stored at \(CodexAuth.defaultAuthPath)")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+
+                Button(action: importCodex) {
+                    Label(isAdding ? "Importing…" : "Import Codex Account",
+                          systemImage: "person.badge.key")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(isAdding)
+            }
+
             // Import results
             if !envImportResults.isEmpty {
                 VStack(alignment: .leading, spacing: 4) {
@@ -1049,7 +1120,8 @@ struct AddAccountView: View {
             if let msg = statusMessage {
                 Text(msg)
                     .font(.caption)
-                    .foregroundColor(msg.contains("Error") || msg.contains("Invalid") || msg.contains("No ") ? .orange : .green)
+                    .foregroundColor(msg.contains("Error") || msg.contains("Invalid")
+                                     || msg.contains("Failed") || msg.contains("No ") ? .orange : .green)
             }
 
             Spacer()
@@ -1087,6 +1159,26 @@ struct AddAccountView: View {
                     onImported?()
                 } else {
                     statusMessage = error ?? "Failed to add account"
+                }
+            }
+        }
+    }
+
+    private func importCodex() {
+        isAdding = true
+        statusMessage = nil
+        store.ensureDatabase()
+
+        Task {
+            let (accountId, error) = await oauthPoller.importCodexCredential()
+            await MainActor.run {
+                isAdding = false
+                if accountId != nil {
+                    statusMessage = "Added OpenAI account"
+                    store.loadFromDatabase()
+                    onImported?()
+                } else {
+                    statusMessage = error ?? "Failed to import Codex credential"
                 }
             }
         }

--- a/menubar-app/ClaudeMonitor/Sources/main.swift
+++ b/menubar-app/ClaudeMonitor/Sources/main.swift
@@ -56,6 +56,8 @@ enum ClaudeMonitorEntry {
         // without also passing --headless.
         if CommandLine.arguments.dropFirst().first == "accounts" {
             AccountSyncCLI.main(Array(CommandLine.arguments.dropFirst(2)))
+        } else if CommandLine.arguments.dropFirst().first == "codex" {
+            CodexCLI.main(Array(CommandLine.arguments.dropFirst(2)))
         } else if CommandLine.arguments.dropFirst().first == "selftest" {
             SelfTest.main(Array(CommandLine.arguments.dropFirst(2)))
         } else if CommandLine.arguments.contains("--headless") {


### PR DESCRIPTION
## Summary

Ships the OpenAI/ChatGPT (Codex) polling path on top of phase 2's provider
abstraction, using the live-verified contract in
`docs/spikes/2026-07-30-codex-usage-probe.md` § "Live verification". OpenAI
accounts now sit in the same table as Anthropic ones, are polled on the same
cadence, and appear in `ranking.json` tagged with their provider.

The two findings that broke the original static analysis are honored
structurally, not just documented: window kind is derived from
`limit_window_seconds` (never from `primary`/`secondary` position), and a null
`secondary_window` produces *no* session window rather than a 0% one.

## Changes

**New — `Sources/OpenAIAPI.swift`**
- `OpenAIAPIClient` conforming to `UsageProviderClient`. `GET
  chatgpt.com/backend-api/wham/usage` (never `/backend-api/codex/usage`, which
  is Cloudflare-challenged) mapped onto the shared `RateLimitSnapshot`.
  Per-model `additional_rate_limits[]` land in the snapshot's `named` map;
  identity (`email` / `plan_type` / `account_id`) is read from the same
  response, so there is no separate profile call.
- Token refresh via `POST auth.openai.com/oauth/token`, with `expires_in` or
  the access token's own `exp` claim as the expiry source (~10 days).
- `CodexAuth` reads Codex CLI's `~/.codex/auth.json`, honoring `$CODEX_HOME`.

**New — `Sources/CodexCLI.swift`**: `claude-monitor codex import [--auth <path>]
[--db <path>]`, a one-shot CLI (no `--headless` needed) that works on Linux.

**`Sources/OAuthPoller.swift`**
- Per-provider poll paths; a single provider-agnostic DB writer replaces the
  Anthropic-only one. Absent windows are stored as **NULL**, not 0, so a
  window-less provider can't inflate its apparent headroom. Anthropic's
  long-standing `?? 0` behavior is untouched.
- Proactive refresh 6h ahead of expiry, never reactive-on-401. Failure is loud:
  a new `CredentialExpiredError` keeps the `.expired` state (red dot) and its
  actionable message from being flattened to the generic "revoked" by the retry
  loop; a failed-but-still-valid renewal shows `.refreshing` (yellow) with the
  reason, and that warning survives a subsequent successful read.
- Fable probes, the `ACCOUNT_KEY_N` env export, and paste-replace semantics are
  now scoped to Anthropic accounts — an Anthropic-only paste can no longer
  delete OpenAI accounts the env format cannot express.

**`Sources/RankingExporter.swift`**: every account carries `provider`.
`schema` deliberately stays **1** (see Risks below). Adds an explicit
`exportNow(dbPath:outputPath:)` for scratch-path testing.

**`Sources/UsagePopoverView.swift`**: per-row `ProviderBadge` inside the
existing Account column (no column-width or popover-width changes); an "Import
Codex Account" button; Roll Token hidden for non-Anthropic rows.

**Docs**: README gains "Adding an OpenAI (Codex) Account" and a full
"Ranking Export (`ranking.json`)" section written for loom-daemon; the spike doc
records the refresh-endpoint probe result.

## Security

- No token value or raw response body is ever logged. Error paths surface only
  the OAuth error *code*.
- The archived field map redacts credential/PII keys **at every nesting depth**,
  which is the exact miss flagged in spike #26's process note. A self-test
  asserts on a deliberately nested `email`/`name` claim.
- Every test uses explicit scratch paths, never `$HOME`-relative defaults
  (`homeDirectoryForCurrentUser` ignores a `HOME` override on macOS — issue #16).
  Scratch data created during manual verification was deleted.

## Acceptance Criteria Verification

- [x] **An OpenAI account can be added and shows live usage alongside Anthropic
  accounts.** Verified end-to-end against the real credential into a *scratch*
  database seeded with a legacy (pre-migration) Anthropic account. Result: the
  legacy row migrated in place as `anthropic`, the new row landed as
  `provider=openai, plan=pro`, `usage_history` recorded `weekly=14%` with
  `session_percent = NULL`, and `oauth_credentials` stored the refresh token
  plus `token_expires_at = 2026-08-08T21:59:15Z`.
- [x] **Token refresh exercised against the real endpoint.** `POST
  auth.openai.com/oauth/token` was probed with the exact request the client
  sends and a deliberately invalid refresh token. It returned **401** with
  `{"error":{"code":"invalid_refresh_token", ...}}` — proving the endpoint, the
  JSON (not form-encoded) body, the `client_id`, and the `grant_type` are all
  accepted, with only the token itself rejected. It also revealed the error body
  is **nested**, not the flat RFC 6749 string, which the client's error
  extraction is written against and a self-test now pins.
  **A successful exchange was deliberately not run** — see Risks.
- [x] **An expired/unrefreshable token is a visible state, not a silent
  failure.** Verified with a synthetic already-expired `auth.json`: fails loudly
  (`Invalid OpenAI credential: Unauthorized — token may be expired or revoked`,
  exit 1) with no token material in the message. In the poll loop this is
  `.expired` (red) with the actionable message preserved.
- [x] **`ranking.json` carries `provider`; existing consumers unaffected.**
  Generated output: Anthropic row unchanged (`5h` + `7d`), OpenAI row
  `{"provider":"openai","utilization":{"7d":0.14}}` with **no `5h` key**,
  `schema` still 1, no credential material anywhere in the file.
- [x] **A null `secondary_window` renders correctly (no fabricated session %).**
  NULL in the DB, key omitted from `ranking.json`, `—` in the popover, and the
  headroom score computed from the weekly window alone (86).
- [x] **`swift build` clean on macOS and Linux headless.** Both verified; see
  Test Plan.

## Test Plan

- `swift build` on macOS — clean (only pre-existing warnings).
- **Linux verified for real, not reasoned about**: `docker run swift:6.1` +
  `libsqlite3-dev`, `swift build` exit 0, `selftest` 99/99 passing, and
  `codex --help` working from the Linux binary. One genuine portability bug was
  caught this way and fixed: `CFGetTypeID`/`CFBooleanGetTypeID` don't exist on
  Linux, so the archive flattener now walks a `JSONValue` decoded by
  `JSONDecoder` instead (which also keeps booleans distinct from 0/1 portably).
- `ClaudeMonitor selftest` — **99 checks**, up from 60, on both platforms.
  New coverage: the recorded wire body (weekly-primary + null-secondary,
  reordered windows, `limit_reached` → `rejected`, missing `account_id` throws),
  nested-PII redaction, JWT `exp` parsing, both OAuth error-body shapes,
  `auth.json` parsing from a scratch path, and the `ranking.json` export
  (provider present, `5h` omitted, schema unchanged, no secrets).
- `ClaudeMonitor selftest --wire <path>` — new flag that decodes a captured
  `/wham/usage` body offline and prints only derived numbers. Run against the
  real captured (scrubbed) response: mapped to weekly 14% / session none /
  headroom 86 / named `GPT-5.3-Codex-Spark` / 37 archived fields, PII redacted.

## Risks / Notes

- **A successful token refresh was not executed.** OAuth refresh may rotate the
  refresh token, which would invalidate the copy in `~/.codex/auth.json` and
  break the operator's Codex CLI login. The negative probe establishes the whole
  request contract short of that, and the client handles both outcomes (keeps
  the stored refresh token when none comes back, replaces it when one does).
  Documented in the README and in the spike doc's "Still unverified".
- **`schema` stays 1 on purpose.** The version tracks breaking changes; bumping
  it risks a strict consumer rejecting the document over a purely additive key.
  The README spells out the contract for loom-daemon, including that a missing
  `utilization["5h"]` means *unknown*, not 0.
- **Punted (worth a follow-up issue):** charting `additional_rate_limits[]` per
  model in the per-account chart window. The data is captured end-to-end today —
  it reaches `RateLimitSnapshot.named` and the `probe_snapshots` archive — but
  surfacing it in `UsageChartView` needs its own history/storage shape, which
  would have doubled this diff. Nothing here blocks it.
- Unrelated pre-existing warnings in `AnthropicAPI.swift` / `UsageStore.swift`
  were left alone.

Closes #29