### PR TITLE
feat: persist and chart OpenAI per-model sub-limits (named_limits)

### DIFF
--- a/menubar-app/ClaudeMonitor/Sources/OAuthPoller.swift
+++ b/menubar-app/ClaudeMonitor/Sources/OAuthPoller.swift
@@ -919,7 +919,8 @@ class OAuthPoller: ObservableObject {
             weeklyReset: windows.weekly?.resetAtISO,
             rawFields: ping.rawHeaders,
             probeModel: "haiku",
-            httpStatus: ping.httpStatus
+            httpStatus: ping.httpStatus,
+            namedLimits: windows.named
         )
     }
 
@@ -939,12 +940,18 @@ class OAuthPoller: ObservableObject {
             weeklyReset: windows.weekly?.resetAtISO,
             rawFields: snapshot.rawFields,
             probeModel: "\(snapshot.provider.rawValue)-usage",
-            httpStatus: snapshot.httpStatus
+            httpStatus: snapshot.httpStatus,
+            namedLimits: windows.named
         )
     }
 
     /// The single write path for both providers: one `usage_history` row plus a
     /// verbatim `probe_snapshots` archive entry.
+    ///
+    /// `namedLimits` additionally writes one `named_limits` row per entry
+    /// (OpenAI's `additional_rate_limits[]`), stamped with the same timestamp
+    /// as the `usage_history` row. Empty for Anthropic pings today, so those
+    /// accounts continue to produce zero `named_limits` rows.
     private func writeUsageToDB(
         accountId: String,
         sessionPercent: Double?,
@@ -953,7 +960,8 @@ class OAuthPoller: ObservableObject {
         weeklyReset: String?,
         rawFields: [String: String],
         probeModel: String,
-        httpStatus: Int
+        httpStatus: Int,
+        namedLimits: [String: RateLimitWindow] = [:]
     ) {
         guard FileManager.default.fileExists(atPath: dbPath) else { return }
 
@@ -1004,6 +1012,8 @@ class OAuthPoller: ObservableObject {
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
             """, accountId, now, primaryPercent, sessionPercent,
                weeklyPercent, 0.0, sessionReset, weeklyReset, rawData)
+
+            UsageStore.insertNamedLimits(db, accountId: accountId, timestamp: now, named: namedLimits)
 
             try db.run("UPDATE accounts SET last_updated = ? WHERE id = ?", now, accountId)
 

--- a/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
+++ b/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
@@ -49,6 +49,7 @@ enum SelfTest {
         testCodexAuthParsing()
         testSchemaMigrationFromPreMigrationDatabase()
         testRankingExportCarriesProvider()
+        testNamedLimitsRoundTrip()
 
         if let idx = arguments.firstIndex(of: "--db"), idx + 1 < arguments.count {
             testMigrationOfExistingDatabase(at: arguments[idx + 1])
@@ -430,6 +431,60 @@ enum SelfTest {
         } catch {
             checks += 1
             failures.append("Codex auth parsing test threw: \(error)")
+        }
+    }
+
+    // MARK: - Named limits (per-model sub-limits, #32)
+
+    /// Decodes a fixture carrying `additional_rate_limits[]`, writes the
+    /// resulting `named` map into a throwaway database via
+    /// `UsageStore.insertNamedLimits` (the same helper `OAuthPoller` calls on
+    /// every poll), then reads it back via `loadNamedLimitHistory` and
+    /// confirms `limit_name` / `used_percent` survive the round trip.
+    private static func testNamedLimitsRoundTrip() {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("claude-monitor-selftest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let dbPath = dir.appendingPathComponent("usage.db").path
+
+            let store = UsageStore(dbPath: dbPath)
+            store.ensureDatabase()
+
+            let snapshot = try OpenAIAPIClient.snapshot(
+                from: Data(openAIUsageFixture.utf8), httpStatus: 200
+            )
+            let named = snapshot.rateLimit.named
+            expect(!named.isEmpty, "fixture must decode at least one named sub-limit")
+
+            let db = try openDatabase(dbPath)
+            let now = ISO8601DateFormatter().string(from: Date())
+            UsageStore.insertNamedLimits(db, accountId: "acct-fixture", timestamp: now, named: named)
+
+            let history = store.loadNamedLimitHistory(for: "acct-fixture")
+            expectEqual(history.count, 1, "one series per distinct limit_name")
+            let series = history["GPT-5.3-Codex-Spark"]
+            expect(series != nil, "the fixture's limit_name is preserved verbatim as the series key")
+            expectEqual(series?.first?.usedPercent, 62,
+                        "used_percent round-trips through named_limits")
+
+            // An account with no named limits at all must read back empty —
+            // this is what lets the chart overlay stay hidden for every
+            // Anthropic account.
+            let emptyHistory = store.loadNamedLimitHistory(for: "acct-with-no-named-limits")
+            expect(emptyHistory.isEmpty, "an account with zero named_limits rows reads back an empty dictionary")
+
+            // Anthropic's ping response never populates `named` — confirm the
+            // write path is a true no-op for it, not merely untested.
+            UsageStore.insertNamedLimits(db, accountId: "acct-anthropic", timestamp: now, named: [:])
+            let anthropicCount = try db.scalar(
+                "SELECT COUNT(*) FROM named_limits WHERE account_id = 'acct-anthropic'"
+            ) as? Int64
+            expectEqual(anthropicCount, 0, "an empty named map writes zero named_limits rows")
+        } catch {
+            checks += 1
+            failures.append("named limits round-trip test threw: \(error)")
         }
     }
 

--- a/menubar-app/ClaudeMonitor/Sources/UsageChartView.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageChartView.swift
@@ -26,6 +26,16 @@ struct TokenTrace: Identifiable {
     let isPrimary: Bool
 }
 
+/// One named sub-limit's overlay series (e.g. an OpenAI
+/// `additional_rate_limits[]` entry). Named by the provider — the label is
+/// used verbatim, never mapped to a fixed enum, since naming will churn.
+struct NamedLimitTrace: Identifiable {
+    let id: String  // the provider's limit_name, doubling as a stable-enough series key
+    let name: String
+    let dataPoints: [NamedLimitDataPoint]
+    let color: Color
+}
+
 struct UsageChartWindow: View {
     let account: Account
     let dataPoints: [UsageDataPoint]
@@ -35,6 +45,7 @@ struct UsageChartWindow: View {
     let oauthPoller: OAuthPoller?
     let otherAccountsData: [AccountTrace]  // Data for other accounts
     let otherTokenData: [TokenTrace]  // Token data for other accounts
+    let namedLimitTraces: [NamedLimitTrace]  // Per-model sub-limits for this account (empty for Anthropic)
     @Environment(\.colorScheme) var colorScheme
     @StateObject private var updateChecker = UpdateChecker.shared
     @State private var isEditingName = false
@@ -125,6 +136,23 @@ struct UsageChartWindow: View {
                 dataPoints: trace.dataPoints.filter { $0.timestamp >= startDate && $0.timestamp <= endDate },
                 color: trace.color,
                 isPrimary: trace.isPrimary
+            )
+        }
+    }
+
+    /// Filtered named-limit traces based on the current range selection.
+    /// Empty when the account has no named limits — callers must check this
+    /// before rendering anything so the overlay stays entirely hidden.
+    var filteredNamedLimitTraces: [NamedLimitTrace] {
+        guard !namedLimitTraces.isEmpty else { return [] }
+        let startDate = dateForRangePosition(rangeStart)
+        let endDate = dateForRangePosition(rangeEnd)
+        return namedLimitTraces.map { trace in
+            NamedLimitTrace(
+                id: trace.id,
+                name: trace.name,
+                dataPoints: trace.dataPoints.filter { $0.timestamp >= startDate && $0.timestamp <= endDate },
+                color: trace.color
             )
         }
     }
@@ -369,6 +397,28 @@ struct UsageChartWindow: View {
                             }
                         }
 
+                        // Named per-model sub-limits (OpenAI additional_rate_limits[]),
+                        // drawn beneath the primary trace. Empty (and therefore
+                        // invisible) for every account with no named limits.
+                        ForEach(filteredNamedLimitTraces) { trace in
+                            ForEach(trace.dataPoints) { point in
+                                LineMark(
+                                    x: .value("Time", point.timestamp),
+                                    y: .value("Usage %", point.usedPercent),
+                                    series: .value("NamedLimit", trace.id)
+                                )
+                                .foregroundStyle(trace.color)
+                                .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
+
+                                PointMark(
+                                    x: .value("Time", point.timestamp),
+                                    y: .value("Usage %", point.usedPercent)
+                                )
+                                .foregroundStyle(trace.color)
+                                .symbolSize(15)
+                            }
+                        }
+
                         // Primary account (blue)
                         ForEach(filteredDataPoints) { point in
                             LineMark(
@@ -489,6 +539,26 @@ struct UsageChartWindow: View {
                             ForEach(otherAccountsData) { trace in
                                 HStack(spacing: 4) {
                                     Circle().fill(trace.color).frame(width: 8, height: 8)
+                                    Text(trace.name)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                        }
+                        .padding(.top, 4)
+                    }
+
+                    // Legend for named per-model sub-limits — only rendered when the
+                    // account actually has at least one, so an Anthropic account (or
+                    // an OpenAI account before this shipped) shows nothing extra.
+                    if chartMode == .percent && !namedLimitTraces.isEmpty {
+                        HStack(spacing: 16) {
+                            ForEach(namedLimitTraces) { trace in
+                                HStack(spacing: 4) {
+                                    Rectangle()
+                                        .fill(trace.color)
+                                        .frame(width: 10, height: 2)
                                     Text(trace.name)
                                         .font(.caption)
                                         .foregroundColor(.secondary)
@@ -1064,6 +1134,15 @@ class ChartWindowController {
         .orange, .green, .purple, .pink, .cyan, .yellow, .mint, .indigo
     ]
 
+    // Colors for named per-model sub-limit overlays. A separate palette from
+    // `otherAccountColors` so the two legends never read as related. Assigned
+    // positionally by sorted `limit_name` (not by hashing the name into this
+    // array), so a renamed model gets whatever slot its new name sorts into —
+    // never silently inheriting another model's prior color out of coincidence.
+    static let namedLimitColors: [Color] = [
+        .teal, .brown, .indigo, .pink, .mint, .orange, .purple, .cyan
+    ]
+
     static func showChart(for account: Account, store: UsageStore, oauthPoller: OAuthPoller? = nil) {
         // Close existing window for this account if open
         if let existing = windows[account.id] {
@@ -1074,6 +1153,23 @@ class ChartWindowController {
         let dataPoints = store.loadHistory(for: account.id)
         let fullDataPoints = store.loadFullHistory(for: account.id)
         let tokenDataPoints = store.loadTokenHistory(for: account.id)
+
+        // Named per-model sub-limits (OpenAI additional_rate_limits[]), one
+        // series per provider-chosen limit_name. Empty for Anthropic accounts
+        // and for any account with none recorded — the chart hides the
+        // overlay entirely in that case.
+        let namedLimitHistory = store.loadNamedLimitHistory(for: account.id)
+        let namedLimitTraces: [NamedLimitTrace] = namedLimitHistory.keys.sorted().enumerated().compactMap {
+            index, limitName in
+            guard let points = namedLimitHistory[limitName], !points.isEmpty else { return nil }
+            let colorIndex = index % namedLimitColors.count
+            return NamedLimitTrace(
+                id: limitName,
+                name: limitName,
+                dataPoints: points.sorted { $0.timestamp < $1.timestamp },
+                color: namedLimitColors[colorIndex]
+            )
+        }
 
         // Load data for other accounts
         var otherAccountsData: [AccountTrace] = []
@@ -1112,7 +1208,8 @@ class ChartWindowController {
             store: store,
             oauthPoller: oauthPoller,
             otherAccountsData: otherAccountsData,
-            otherTokenData: otherTokenData
+            otherTokenData: otherTokenData,
+            namedLimitTraces: namedLimitTraces
         )
         let hostingController = NSHostingController(rootView: chartView)
 

--- a/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
@@ -175,6 +175,15 @@ struct FullUsageDataPoint: Identifiable {
     let weeklyAllPercent: Double?
 }
 
+/// One reading of a single named sub-limit (`named_limits` table) — one series
+/// per provider-chosen `limit_name`, e.g. OpenAI's `additional_rate_limits[]`
+/// entries. Anthropic accounts never populate this today.
+struct NamedLimitDataPoint: Identifiable {
+    let id = UUID()
+    let timestamp: Date
+    let usedPercent: Double
+}
+
 struct TokenDataPoint: Identifiable {
     let id = UUID()
     let timestamp: Date
@@ -294,9 +303,21 @@ class UsageStore: ObservableObject {
                 headers TEXT NOT NULL,
                 FOREIGN KEY (account_id) REFERENCES accounts(id)
             );
+            CREATE TABLE IF NOT EXISTS named_limits (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_id TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                limit_name TEXT NOT NULL,
+                used_percent REAL,
+                window_seconds REAL,
+                reset_at TEXT,
+                FOREIGN KEY (account_id) REFERENCES accounts(id)
+            );
             CREATE INDEX IF NOT EXISTS idx_usage_account ON usage_history(account_id);
             CREATE INDEX IF NOT EXISTS idx_usage_timestamp ON usage_history(timestamp DESC);
             CREATE INDEX IF NOT EXISTS idx_probe_account_time ON probe_snapshots(account_id, timestamp DESC);
+            CREATE INDEX IF NOT EXISTS idx_named_limits_account_time
+                ON named_limits(account_id, limit_name, timestamp DESC);
             CREATE TABLE IF NOT EXISTS oauth_credentials (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 account_id TEXT,
@@ -466,6 +487,36 @@ class UsageStore: ObservableObject {
     static func parseHeaders(_ json: String) -> [String: String]? {
         guard let data = json.data(using: .utf8) else { return nil }
         return (try? JSONDecoder().decode([String: String].self, from: data))
+    }
+
+    /// Write one `named_limits` row per entry in `named`, all stamped with the
+    /// same `timestamp` as the sibling `usage_history` row so the two can be
+    /// joined on `(account_id, timestamp)` if ever needed.
+    ///
+    /// `named` is empty for every Anthropic reading today (the ping response
+    /// never populates `RateLimitSnapshot.named`), so this is a silent no-op
+    /// for those accounts — exactly the "zero named_limits rows" behavior the
+    /// chart overlay depends on to stay hidden.
+    static func insertNamedLimits(
+        _ db: Connection,
+        accountId: String,
+        timestamp: String,
+        named: [String: RateLimitWindow]
+    ) {
+        for (limitName, window) in named {
+            do {
+                try db.run("""
+                    INSERT INTO named_limits (account_id, timestamp, limit_name, used_percent, window_seconds, reset_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                """, accountId, timestamp, limitName, window.usedPercent,
+                   window.durationSeconds, window.resetAtISO)
+            } catch {
+                FileLogger.shared.error(
+                    "Failed to write named_limits row for \(limitName): \(error.localizedDescription)",
+                    category: "DB"
+                )
+            }
+        }
     }
 
     func loadFromDatabase() {
@@ -717,6 +768,47 @@ class UsageStore: ObservableObject {
         } catch {
             print("Error loading full history: \(error)")
             return []
+        }
+    }
+
+    /// Named per-model / per-feature sub-limit history (`named_limits`),
+    /// grouped by the provider-chosen `limit_name` — one time series per key,
+    /// ascending by timestamp. Returns an empty dictionary for every account
+    /// with no named limits (every Anthropic account today), which is what
+    /// lets `UsageChartView` hide the overlay entirely rather than rendering
+    /// an empty series.
+    func loadNamedLimitHistory(for accountId: String, daysBack: Int = 7) -> [String: [NamedLimitDataPoint]] {
+        do {
+            guard FileManager.default.fileExists(atPath: dbPath) else {
+                return [:]
+            }
+
+            let db = try openDatabase(dbPath, readonly: true)
+            guard tableColumns(db, "named_limits").contains("limit_name") else { return [:] }
+
+            let cutoffDate = Date().addingTimeInterval(-Double(daysBack) * 24 * 60 * 60)
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            let cutoffString = formatter.string(from: cutoffDate)
+
+            let stmt = try db.prepare("""
+                SELECT limit_name, timestamp, used_percent FROM named_limits
+                WHERE account_id = ? AND timestamp >= ?
+                ORDER BY limit_name, timestamp ASC
+            """)
+
+            var result: [String: [NamedLimitDataPoint]] = [:]
+            for row in stmt.bind(accountId, cutoffString) {
+                guard let limitName = row[0] as? String,
+                      let date = parseDate(row[1] as? String),
+                      let percent = row[2] as? Double else { continue }
+                result[limitName, default: []].append(NamedLimitDataPoint(timestamp: date, usedPercent: percent))
+            }
+            return result
+
+        } catch {
+            print("Error loading named limit history: \(error)")
+            return [:]
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds a `named_limits` table (`account_id`, `timestamp`, `limit_name`, `used_percent`, `window_seconds`, `reset_at`) to `applySchema`, alongside its own index, so `RateLimitSnapshot.named` (OpenAI's `additional_rate_limits[]`) survives as a queryable time series rather than only a verbatim `probe_snapshots.headers` JSON blob.
- `OAuthPoller.writeUsageToDB` now writes one `named_limits` row per entry in the snapshot's `named` map, stamped with the same timestamp as the sibling `usage_history` row. Both `writeSnapshotToDB` (OpenAI) and `writePingToDB` (Anthropic) pass their respective `rateLimit.named` map through — Anthropic's ping response never populates `named`, so this remains a true no-op for those accounts.
- `UsageStore.loadNamedLimitHistory(for:daysBack:)` reads the table back, grouped by `limit_name`, ascending by timestamp.
- `UsageChartView` renders one overlay series per distinct `limit_name`, using the provider's name verbatim as the label, entirely hidden (no legend, no empty series) when an account has zero named limits.
- `SelfTest.swift` adds `testNamedLimitsRoundTrip`: decodes the existing `additional_rate_limits[]` fixture, writes it via `UsageStore.insertNamedLimits`, reads it back, and confirms `limit_name`/`used_percent` round-trip; also asserts an empty `named` map writes zero rows and an account with no rows reads back empty.

## Changes

- `menubar-app/ClaudeMonitor/Sources/UsageStore.swift` — `named_limits` table + index in `applySchema`; `NamedLimitDataPoint` struct; `UsageStore.insertNamedLimits` (static writer, shared by `OAuthPoller` and the self-test); `loadNamedLimitHistory(for:daysBack:)` reader.
- `menubar-app/ClaudeMonitor/Sources/OAuthPoller.swift` — `writeUsageToDB` gains a `namedLimits` parameter (default `[:]`); `writeSnapshotToDB` / `writePingToDB` pass `rateLimit.named` through.
- `menubar-app/ClaudeMonitor/Sources/UsageChartView.swift` — `NamedLimitTrace` type; a dedicated `namedLimitColors` palette assigned positionally by sorted `limit_name`; overlay series + legend in the percent chart, gated on `!namedLimitTraces.isEmpty`; `ChartWindowController.showChart` loads and builds the traces.
- `menubar-app/ClaudeMonitor/Sources/SelfTest.swift` — `testNamedLimitsRoundTrip`.

`RateLimitWindow.swift` was reviewed per the issue's Affected Files list but needed no change — its existing `durationSeconds` / `resetAtISO` accessors already cover the writer's needs.

## Acceptance Criteria Verification

- [x] `named_limits` table with nullable `window_seconds` / `reset_at`, mirroring the existing nullable-window convention.
- [x] `OAuthPoller.writeSnapshotToDB` (and `writePingToDB`) write one row per `named` entry alongside the `usage_history` insert, same timestamp.
- [x] Anthropic accounts write zero `named_limits` rows — confirmed both by code inspection (ping's `rateLimit.named` is always `[:]`) and by an explicit selftest assertion (`insertNamedLimits` with an empty map writes zero rows).
- [x] `UsageStore.loadNamedLimitHistory(for:daysBack:)` added, analogous to `loadFullHistory`.
- [x] `UsageChartView` renders one overlay per distinct `limit_name`, only when at least one exists; verified by gating both the chart `ForEach` and the legend `HStack` on `!namedLimitTraces.isEmpty` / `!filteredNamedLimitTraces.isEmpty`.
- [x] Series labels use the provider name verbatim — no enum mapping.
- [x] No token/PII touched — the writer only consumes the already-decoded, already-redacted `RateLimitWindow` values.
- [x] `swift build && .build/debug/ClaudeMonitor selftest` passes (105 checks, up from 104), including the new round-trip assertion.
- [x] Linux headless build verified via `swift:6.1` Docker image (`apt-get install libsqlite3-dev && swift build`) — same 105 checks pass. Schema + writer changes are in portable core; only `UsageChartView` is `#if os(macOS)`.
- [x] `ranking.json` extension explicitly left out of scope per the issue's own deferral.

## Test Plan

- [x] `swift build && .build/debug/ClaudeMonitor selftest` — 105/105 checks pass.
- [x] Linux build + selftest via `swift:6.1` Docker image — 105/105 checks pass.
- [ ] Manual verification (ChatGPT Pro/Codex account with an active `additional_rate_limits[]` entry): poll at least twice, open the chart window, confirm the overlay appears and updates. (Not performed in this PR — no live OpenAI/Codex credential available in this environment; covered by the automated fixture round-trip instead.)
- [x] Edge case: an account with zero named limits renders identically to before — verified via the empty-history selftest assertion and the `!namedLimitTraces.isEmpty` gates in the view.
- [x] Edge case: a renamed limit naturally appears as a second series (keyed by `limit_name`, not a synthetic id) — this falls out of the dictionary-keyed storage/read shape, no special-casing needed.
- [x] No token/PII in the new table or any touched log line — `insertNamedLimits` only ever receives `RateLimitWindow` values, which carry no identity fields.

Closes #32