### PR TITLE
fix: grow the mascot to 16x13 to balance against the rosette

### DIFF
--- a/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
@@ -137,15 +137,25 @@ struct ProviderBadge: View {
 /// as image assets — the package ships no resources and has no dependencies,
 /// and a handful of filled rects stays crisp at any scale factor.
 private enum ProviderGlyph {
-    /// The Claude Code mascot, transcribed cell-for-cell from the 16×10
-    /// original: eyes in columns 4 and 11, four legs at 3/5/10/12.
+    /// The Claude Code mascot: eyes in columns 4 and 11, four legs at
+    /// 3/5/10/12, drawn 16×13.
+    ///
+    /// The source art is 16×10. Beside the rosette — which fills its whole
+    /// 16×16 box — that read noticeably light, so three rows are added to the
+    /// body and arm band. Growing those rather than scaling the whole sprite
+    /// keeps one cell = one point (a proportional 1.3× would land on
+    /// half-pixels and resample the art), and keeps the legs stubby: lengthening
+    /// them instead made the creature spindly.
     static let anthropic = [
         "..############..",
         "..############..",
+        "..############..",
         "..##.######.##..",
         "..##.######.##..",
         "################",
         "################",
+        "################",
+        "..############..",
         "..############..",
         "..############..",
         "...#.#....#.#...",


### PR DESCRIPTION
Operator feedback on #36: the OpenAI rosette is visually heavier than the mascot; make the mascot ~3 pixels taller to balance.

## Change

Mascot grows 16×10 → **16×13**, with the three rows added to the body and arm band.

Two things I deliberately did *not* do:

- **Scale the sprite proportionally.** 1.3× would put the mascot at 20.8×13, landing on half-pixels and resampling art that only looks right on whole cells. Growing rows keeps one cell = one point, so both glyphs stay crisp.
- **Lengthen the legs** to absorb the extra height. Tried it — the creature goes spindly and loses its stubby character. The arm band and body carry the weight instead.

Compared three distributions (body+legs, +eye rows, body-only) rendered side by side against the rosette before picking; the body/arm-band version holds the silhouette best.

Trade-off worth stating: this is **no longer a cell-exact transcription** of the 16×10 source. The silhouette is intentionally chunkier for optical balance in the row, and the comment in `ProviderGlyph.anthropic` says so.

## Verification

Rendered from the exact bitmap in the source and inspected at true badge size in a mocked popover row. `swift build` clean; `selftest` 115/115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)