### PR TITLE
docs: clarify local swift build does not gate strict-concurrency errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 - To verify a schema migration against real data, copy the live DB first — `cp ~/.claude-monitor/usage.db /tmp/ && .build/debug/ClaudeMonitor selftest --db /tmp/usage.db`. `--db` **writes** to the path it is given; never point it at `~/.claude-monitor/usage.db`.
 - Parse response headers via `extractAnthropicHeaders` (lowercased map), never `allHeaderFields` subscripts — those are case-sensitive on Linux.
 - Verify Linux builds from macOS with the `swift:6.1` Docker image (`apt-get install libsqlite3-dev`, then `swift build`).
+- **A clean local `swift build` is weak evidence for Swift strict-concurrency errors** (e.g. "mutation of captured var in concurrently-executing code") — a newer local toolchain (6.3.3+) can downgrade these to warnings under region-based isolation while CI's pinned `macos-14` Xcode still hard-errors on them. CI is authoritative for this bug class. Before pushing, run the stronger local proxy `swift build -Xswiftc -swift-version -Xswiftc 6` (forces Swift 6 language mode, surfacing the same diagnostics CI's toolchain flags). Adopting Swift 6 language mode package-wide would make local and CI agree by construction, but that's a bigger change than this note and hasn't been done yet.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- Adds a note to `CLAUDE.md`'s Headless/Linux section documenting that a clean local `swift build` is weak evidence for Swift strict-concurrency diagnostics (e.g. captured-var mutation in concurrent code): newer local toolchains (6.3.3+) can downgrade these to warnings under region-based isolation, while CI's pinned `macos-14` Xcode still hard-errors on them.
- Documents the stronger local proxy check to run before pushing: `swift build -Xswiftc -swift-version -Xswiftc 6`.
- Notes (without mandating) that adopting Swift 6 language mode package-wide would make local and CI agree by construction — a bigger change left for future consideration.

Documentation-only change; no code touched.

Closes #41

## Test plan
- [x] Reviewed rendered CLAUDE.md for tone/format consistency with surrounding bullet points
- N/A build/test — docs-only change