### PR TITLE
fix: tiebreak account ordering on natural display name, not account id

### DIFF
--- a/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
+++ b/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
@@ -40,6 +40,7 @@ enum SelfTest {
         }
 
         testNaturalSort()
+        testSortedAccountsForPopoverTieBreak()
         testWindowKindDerivation()
         testSnapshotFromPositionalWindows()
         testMissingSessionWindow()
@@ -95,6 +96,40 @@ enum SelfTest {
         let result = NaturalSort.selfCheck()
         checks += result.checks
         failures.append(contentsOf: result.failures.map { "naturalSort: \($0)" })
+    }
+
+    /// Two accounts with identical usage and reset must not fall through to
+    /// arbitrary insertion/UUID order (#40): the account id here is chosen to
+    /// *disagree* with natural name order, so a fix that still tiebreaks on
+    /// id would sort these the wrong way.
+    private static func testSortedAccountsForPopoverTieBreak() {
+        let store = UsageStore(dbPath: ":memory:selftest-tiebreak")
+
+        let agentNine = Account(
+            id: "zzz-later-id", accountName: "agent-9", email: nil, plan: "Max",
+            lastUpdated: nil, latestPercent: nil
+        )
+        let agentTen = Account(
+            id: "aaa-earlier-id", accountName: "agent-10", email: nil, plan: "Max",
+            lastUpdated: nil, latestPercent: nil
+        )
+        store.accounts = [agentTen, agentNine]
+
+        func identicalUsage(_ accountId: String, _ recordId: Int64) -> UsageRecord {
+            UsageRecord(
+                id: recordId, accountId: accountId, timestamp: Date(),
+                primaryPercent: 50, sessionPercent: 50, weeklyAllPercent: 20,
+                weeklySONnetPercent: nil, sessionReset: nil, weeklyReset: nil
+            )
+        }
+        store.latestUsage = [
+            agentNine.id: identicalUsage(agentNine.id, 1),
+            agentTen.id: identicalUsage(agentTen.id, 2),
+        ]
+
+        let ordered = store.sortedAccountsForPopover.map { $0.displayName }
+        expectEqual(ordered, ["agent-9", "agent-10"],
+                    "equal usage/reset falls back to natural name order, not account id")
     }
 
     // MARK: - Window model

--- a/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
@@ -280,6 +280,18 @@ struct UsagePopoverView: View {
         return map
     }
 
+    /// Final tiebreak when a column's primary comparison is exactly equal
+    /// (common for freshly-added or idle accounts that all read 0%): order by
+    /// natural display name instead of falling through to arbitrary
+    /// insertion/UUID order, and only fall back to account id when even the
+    /// display names are indistinguishable, so the order stays total and
+    /// stable.
+    private func stableTiebreak(_ a: Account, _ b: Account) -> Bool {
+        let cmp = NaturalSort.compare(a.displayName, b.displayName)
+        if cmp != .orderedSame { return cmp == .orderedAscending }
+        return a.id < b.id
+    }
+
     /// Sort comparator for two rows under the current column/direction.
     /// Rows without data sort to the bottom regardless of direction.
     private func compareRows(_ a: (Account, UsageRecord?), _ b: (Account, UsageRecord?)) -> Bool {
@@ -287,7 +299,7 @@ struct UsagePopoverView: View {
         // agent-10 follows agent-9 instead of landing next to agent-1.
         if case .account = sortBy {
             let cmp = NaturalSort.compare(a.0.displayName, b.0.displayName)
-            if cmp == .orderedSame { return a.0.id < b.0.id }
+            if cmp == .orderedSame { return stableTiebreak(a.0, b.0) }
             return sortDir == .asc
                 ? (cmp == .orderedAscending)
                 : (cmp == .orderedDescending)
@@ -295,11 +307,11 @@ struct UsagePopoverView: View {
 
         let (av, bv) = sortValues(a, b, for: sortBy)
         switch (av, bv) {
-        case (nil, nil): return a.0.id < b.0.id
+        case (nil, nil): return stableTiebreak(a.0, b.0)
         case (nil, _):   return false          // nil rows go last
         case (_, nil):   return true
         case let (.some(x), .some(y)):
-            if x == y { return a.0.id < b.0.id }
+            if x == y { return stableTiebreak(a.0, b.0) }
             return sortDir == .asc ? (x < y) : (x > y)
         }
     }

--- a/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
@@ -478,7 +478,15 @@ class UsageStore: ObservableObject {
             let aEffective = max(aWindows?.session?.usedPercent ?? 0, aWindows?.weekly?.usedPercent ?? 0)
             let bEffective = max(bWindows?.session?.usedPercent ?? 0, bWindows?.weekly?.usedPercent ?? 0)
             if aEffective != bEffective { return aEffective < bEffective }
-            return UsageStore.resetSeconds(a.usage) < UsageStore.resetSeconds(b.usage)
+            let aReset = UsageStore.resetSeconds(a.usage)
+            let bReset = UsageStore.resetSeconds(b.usage)
+            if aReset != bReset { return aReset < bReset }
+            // Usage and reset both tie (common for freshly-added or idle
+            // accounts that all read 0%): order by natural display name
+            // instead of falling through to arbitrary insertion/UUID order.
+            let cmp = NaturalSort.compare(a.account.displayName, b.account.displayName)
+            if cmp != .orderedSame { return cmp == .orderedAscending }
+            return a.account.id < b.account.id
         }
         return sorted.map { $0.account }
     }


### PR DESCRIPTION
## Summary

- `UsageStore.sortedAccountsForPopover` fell through to arbitrary insertion/UUID order (`a.account.id < b.account.id`) when usage percent and reset time both tied — common for freshly-added or idle accounts that all read 0%.
- `UsagePopoverView.compareRows` had the same `a.0.id < b.0.id` fallback in three places (the `.account` column's own tie, the `(nil, nil)` case, and the `x == y` case for every other column).
- PR #34 added `NaturalSort.compare` (hybrid lexical/numeric ordering, so `agent-10` follows `agent-9`) but only wired it into the Account column's primary sort.

## Changes

- `UsageStore.swift`: `sortedAccountsForPopover` now falls back to `NaturalSort.compare` on display name after usage and reset time tie, before falling to account id as the final total-order tiebreak.
- `UsagePopoverView.swift`: extracted a shared `stableTiebreak(_:_:)` helper (natural name, then id) and used it at all three tie-fallback sites in `compareRows`, so the table's default order and the popover's default order agree.
- `SelfTest.swift`: added `testSortedAccountsForPopoverTieBreak`, which seeds two accounts with identical usage/reset but ids that *disagree* with natural name order, and asserts `sortedAccountsForPopover` still orders them `agent-9` before `agent-10`.

## Acceptance Criteria Verification

- [x] `sortedAccountsForPopover` falls back to `NaturalSort.compare` on display name instead of account id when usage and reset times tie — verified by the new selftest.
- [x] `compareRows`'s tie fallbacks do the same, so the table and the default order agree — all three `a.0.id < b.0.id` sites now route through `stableTiebreak`.
- [x] `NaturalSort` stays in the portable core — unchanged, still Foundation-only; the headless Linux build was re-verified end to end.
- [x] A selftest pins that two accounts with identical usage order by natural name — `testSortedAccountsForPopoverTieBreak` in `SelfTest.swift`.

## Test Plan

- `swift build` — clean build, no new warnings.
- `.build/debug/ClaudeMonitor selftest` — 116/116 checks pass (macOS).
- Verified the same build + selftest inside the `swift:6.1` Docker image (`apt-get install libsqlite3-dev`) — 116/116 checks pass on Linux too, confirming the headless daemon target is unaffected.

Closes #40