### PR TITLE
fix: fall back to claude --version for User-Agent detection

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -159,11 +159,16 @@ The build is local — there is no release workflow that produces the `.zip`. Th
    ```bash
    ./scripts/build-macos-app.sh
    ```
-   This produces `build/ClaudeMonitor.app` and `build/ClaudeMonitor.zip`. The script auto-detects the installed `claude-code` version (via npm) and patches the User-Agent in `AnthropicAPI.swift` before compiling — confirm with the user that the local `claude-code` is on the version they want to ship with.
+   This produces `build/ClaudeMonitor.app` and `build/ClaudeMonitor.zip`. The script auto-detects the installed `claude-code` version (via `npm list -g`, falling back to `claude --version` for Homebrew/other installs) and patches the User-Agent in `AnthropicAPI.swift` before compiling — confirm with the user that the local `claude-code` is on the version they want to ship with. If neither detection method finds a version, the script now fails outright rather than silently shipping a stale User-Agent (set `ALLOW_STALE_USER_AGENT=1` to override deliberately).
 
-2. **Verify the `.zip` exists** at `build/ClaudeMonitor.zip` and is non-trivially sized.
+2. **Verify the patched User-Agent** matches the version the script reported (and the `claude-code` version you intend to ship with):
+   ```bash
+   grep claudeCodeUserAgent menubar-app/ClaudeMonitor/Sources/AnthropicAPI.swift
+   ```
 
-3. **Create the GitHub Release** using the CHANGELOG entry as the body:
+3. **Verify the `.zip` exists** at `build/ClaudeMonitor.zip` and is non-trivially sized.
+
+4. **Create the GitHub Release** using the CHANGELOG entry as the body:
    ```bash
    gh release create vX.Y.Z \
      --title "vX.Y.Z" \
@@ -172,7 +177,7 @@ The build is local — there is no release workflow that produces the `.zip`. Th
    ```
    (Manually extract the new entry from CHANGELOG.md if the awk doesn't pick up cleanly — past releases have the body matching the `### Summary` + section bullets, without the `## [X.Y.Z] - DATE` header.)
 
-4. **Verify the release page** shows the `.zip` asset and that the notes render correctly:
+5. **Verify the release page** shows the `.zip` asset and that the notes render correctly:
    ```bash
    gh release view vX.Y.Z --json name,assets,url --jq '.'
    ```
@@ -197,6 +202,6 @@ Present:
 - **Two version-bearing files:** `menubar-app/ClaudeMonitor/Sources/UsageStore.swift` (`AppVersion.current`) and `scripts/build-macos-app.sh` (CFBundleVersion + CFBundleShortVersionString). Keep them in lockstep — `UpdateChecker` compares `AppVersion.current` to GitHub's latest tag, while macOS surfaces the `CFBundleShortVersionString` in About.
 - **Tag format:** `vX.Y.Z` (annotated, with a one-line message).
 - **Build is local.** `.github/workflows/build.yml` only runs `swift build` on push/PR; it does not produce or attach release artifacts.
-- **`build-macos-app.sh` rewrites `AnthropicAPI.swift`** with the locally-installed `claude-code` User-Agent. Confirm that version is what you want to ship.
+- **`build-macos-app.sh` rewrites `AnthropicAPI.swift`** with the locally-installed `claude-code` User-Agent (npm, falling back to `claude --version`). Confirm that version is what you want to ship — if detection fails entirely the script exits non-zero instead of building silently.
 - **Installing the new build** (for sanity check): see CLAUDE.md — you must `rm -rf /Applications/ClaudeMonitor.app` first because `cp -R` doesn't replace a running app.
 - **Do not push or create the release without explicit user confirmation** at each phase.

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -13,14 +13,33 @@ echo "Building macOS app..."
 
 cd "$APP_DIR"
 
-# Auto-detect installed claude-code version for User-Agent header
+# Auto-detect installed claude-code version for User-Agent header.
+# Primary source: the npm global install. This misses Homebrew/other installs
+# (npm list finds nothing), so fall back to `claude --version` in that case.
 CLAUDE_CODE_VERSION=$(npm list -g @anthropic-ai/claude-code --depth=0 2>/dev/null | grep claude-code | sed 's/.*@//')
+
+if [ -z "$CLAUDE_CODE_VERSION" ] && command -v claude >/dev/null 2>&1; then
+    # e.g. "2.1.220 (Claude Code)" -> "2.1.220"
+    CLAUDE_CODE_VERSION=$(claude --version 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
+fi
+
 if [ -n "$CLAUDE_CODE_VERSION" ]; then
     echo "Detected claude-code version: $CLAUDE_CODE_VERSION"
     sed -i '' "s|claude-code/[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*|claude-code/${CLAUDE_CODE_VERSION}|g" \
         Sources/AnthropicAPI.swift
 else
-    echo "Warning: could not detect claude-code version, using existing value"
+    # Shipping a stale User-Agent is a silent correctness bug (it already
+    # happened once at v1.17.0), so this is a hard failure rather than a
+    # warning that's easy to lose in build output. Set
+    # ALLOW_STALE_USER_AGENT=1 to explicitly opt into building anyway with
+    # whatever User-Agent is already committed in AnthropicAPI.swift.
+    echo "ERROR: could not detect claude-code version via 'npm list -g @anthropic-ai/claude-code' or 'claude --version'." >&2
+    echo "       Install claude-code (npm or Homebrew) so it's on PATH before building," >&2
+    echo "       or set ALLOW_STALE_USER_AGENT=1 to build anyway with the existing User-Agent." >&2
+    if [ "${ALLOW_STALE_USER_AGENT:-}" != "1" ]; then
+        exit 1
+    fi
+    echo "ALLOW_STALE_USER_AGENT=1 set — proceeding with the existing (possibly stale) User-Agent." >&2
 fi
 
 # Build release version


### PR DESCRIPTION
## Summary

`scripts/build-macos-app.sh` auto-detects the installed `claude-code` version to patch `claudeCodeUserAgent` in `AnthropicAPI.swift` before compiling. The detection only queried `npm list -g @anthropic-ai/claude-code`, which returns nothing on machines where `claude` is installed via Homebrew — the script then silently kept whatever User-Agent string was already committed, with only an easy-to-miss warning. This already caused a real bug at the v1.17.0 release (stale `claude-code/2.0.37` shipped while the installed CLI was `2.1.220`).

## Changes

- `scripts/build-macos-app.sh`: when the npm query yields nothing, fall back to parsing the leading semver out of `claude --version` (e.g. `2.1.220 (Claude Code)` -> `2.1.220`).
- When neither the npm query nor `claude --version` can detect a version, the build now fails outright (`exit 1`) instead of silently proceeding with a stale value — shipping a stale User-Agent is a correctness bug, not cosmetic. `ALLOW_STALE_USER_AGENT=1` opts into building anyway for the rare case that's deliberate.
- `.claude/commands/release.md`: release checklist now has an explicit step to verify the patched `claudeCodeUserAgent` value against the `claude-code` version intended for shipping, and notes the fallback + hard-failure behavior.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| Detection falls back to `claude --version` when npm query yields nothing | ✅ | On this machine `npm list -g @anthropic-ai/claude-code` returns empty (Homebrew install); running `./scripts/build-macos-app.sh` printed `Detected claude-code version: 2.1.220`, matching `claude --version` output, confirming the fallback path fired |
| Failure to detect by any means is loud / build-failing, not a silent warning | ✅ | Manually simulated the empty-detection branch in isolation — script prints an `ERROR:` message on stderr and `exit 1`s unless `ALLOW_STALE_USER_AGENT=1` is set |
| (Optional) release checklist notes verifying the patched User-Agent | ✅ | Added an explicit verification step + note in `.claude/commands/release.md` Phase 7 |

## Test Plan

- `bash -n scripts/build-macos-app.sh` — syntax check passes
- Ran `./scripts/build-macos-app.sh` end-to-end on a machine with a Homebrew-only `claude` install (no npm global package): detected `2.1.220` via the `claude --version` fallback, patched (already-correct) User-Agent, built `build/ClaudeMonitor.app` successfully
- `cd menubar-app/ClaudeMonitor && swift build && .build/debug/ClaudeMonitor selftest` — build succeeds, `selftest: 115 check(s) passed`
- Manually verified the hard-failure branch (`exit 1` on stderr `ERROR:` message) in an isolated bash snippet mirroring the script's new detection logic

Closes #39