### PR TITLE
macOS: dispatch --version at top level so it never launches the GUI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@
 
 - The same package builds on Linux (`swift build` with `libsqlite3-dev` installed) as a headless daemon for Loom hosts — no UI, same poll loop, same `usage.db`/`ranking.json` outputs. See README "Headless Mode / Linux".
 - UI sources are fenced with `#if os(macOS)`; portable core must stay free of AppKit/SwiftUI/Combine/os.Logger. On Linux, `LinuxCompat.swift` shims `ObservableObject`/`@Published`, and `CSQLite/` maps the system libsqlite3 (macOS uses the SDK's `SQLite3` module).
-- Entry points: `main.swift` (macOS, dispatches to `HeadlessRunner` on `--headless`) and `HeadlessMain.swift` (Linux, always headless). Flags: `--once`, `--interval <sec>`, `--version`. Subcommands: `accounts`, `codex`, `selftest`.
+- Entry points: `main.swift` (macOS, dispatches to `HeadlessRunner` on `--headless`) and `HeadlessMain.swift` (Linux, always headless). Flags: `--once`, `--interval <sec>`, `--version`. Subcommands: `accounts`, `codex`, `selftest`. On macOS, `--version` is dispatched top-level in `main.swift` (works with or without `--headless`, never launches the GUI); bare `--once`/`--interval` (without `--headless`) fail fast with a stderr message instead of falling through to the GUI branch.
 - Run the test suite with `swift build && .build/debug/ClaudeMonitor selftest` (exits non-zero on failure). CI runs it on macOS and Linux.
 - To verify a schema migration against real data, copy the live DB first — `cp ~/.claude-monitor/usage.db /tmp/ && .build/debug/ClaudeMonitor selftest --db /tmp/usage.db`. `--db` **writes** to the path it is given; never point it at `~/.claude-monitor/usage.db`.
 - Parse response headers via `extractAnthropicHeaders` (lowercased map), never `allHeaderFields` subscripts — those are case-sensitive on Linux.

--- a/README.md
+++ b/README.md
@@ -400,6 +400,11 @@ while the daemon runs. A sample systemd user unit is provided at
 
 On macOS the same headless loop is available as `ClaudeMonitor --headless`
 (the bare binary or the app bundle's `Contents/MacOS/ClaudeMonitor`).
+`ClaudeMonitor --version` prints the version and exits on macOS with or
+without `--headless` — it never launches the GUI. `--once` and `--interval`
+are headless-loop flags: bare (without `--headless`) they print an error to
+stderr and exit non-zero rather than launching a duplicate GUI instance, e.g.
+`ClaudeMonitor --headless --once`.
 
 ## Multi-Host Sync
 

--- a/menubar-app/ClaudeMonitor/Sources/main.swift
+++ b/menubar-app/ClaudeMonitor/Sources/main.swift
@@ -60,8 +60,20 @@ enum ClaudeMonitorEntry {
             CodexCLI.main(Array(CommandLine.arguments.dropFirst(2)))
         } else if CommandLine.arguments.dropFirst().first == "selftest" {
             SelfTest.main(Array(CommandLine.arguments.dropFirst(2)))
+        } else if CommandLine.arguments.contains("--version") {
+            // Dispatched at top level (not just inside HeadlessRunner) so
+            // `ClaudeMonitor --version` never falls through to the GUI branch
+            // below — see #46.
+            print("claude-monitor \(AppVersion.current)")
+            exit(0)
         } else if CommandLine.arguments.contains("--headless") {
             HeadlessRunner.main()
+        } else if CommandLine.arguments.contains("--once") || CommandLine.arguments.contains("--interval") {
+            // These are headless-loop flags handled inside HeadlessRunner; bare
+            // (without --headless) they must fail fast rather than silently
+            // launching a duplicate GUI instance — see #46.
+            FileHandle.standardError.write(Data("--once/--interval require --headless on macOS, e.g. `ClaudeMonitor --headless --once`\n".utf8))
+            exit(2)
         } else {
             ClaudeMonitorApp.main()
         }


### PR DESCRIPTION
## Summary

`ClaudeMonitor --version` on macOS fell through to `ClaudeMonitorApp.main()` (the SwiftUI menubar app) instead of printing the version, because `--version`/`--once`/`--interval` were only parsed inside `HeadlessRunner.main()`, which is only reached when `--headless` is also passed. `selftest`/`accounts`/`codex` were already dispatched at top level in `main.swift`; `--version` never got the same treatment when `HeadlessRunner` grew it.

## Fix

In `menubar-app/ClaudeMonitor/Sources/main.swift`'s `ClaudeMonitorEntry.main()`, ordered before the `--headless`/GUI dispatch:

- `--version` now prints `claude-monitor <version>` and exits `0` unconditionally (whether or not `--headless` is present) — it never reaches the GUI branch.
- Bare `--once`/`--interval` (without `--headless`) now fail fast with a clear stderr message and exit `2`, instead of silently launching a duplicate GUI instance.

Docs updated to match (`README.md` "Run" section, `CLAUDE.md` entry-points note).

## Test plan

- [x] `swift build` succeeds (no new warnings/errors introduced)
- [x] `swift build && .build/debug/ClaudeMonitor selftest` — 126 checks passed
- [x] `ClaudeMonitor --version` (bare) prints `claude-monitor 1.18.1` and exits 0, no GUI process spawned
- [x] `ClaudeMonitor --headless --version` unchanged — prints and exits 0
- [x] `ClaudeMonitor --once` (bare) prints `--once/--interval require --headless on macOS, e.g. \`ClaudeMonitor --headless --once\`` to stderr and exits 2
- [x] `ClaudeMonitor --interval 300` (bare) — same fail-fast behavior, exit 2
- [x] `ClaudeMonitor --headless --once` — full poll cycle runs and exits 0 (regression check, unchanged)
- [x] `ClaudeMonitor selftest --help`, `ClaudeMonitor accounts --help`, `ClaudeMonitor codex --help` still dispatch correctly (regression check, unchanged)

Closes #46