### PR TITLE
fix: heal duplicate provider accounts sharing an email at launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ credential when an OpenAI account shares its email address.
   recover the history by reassigning non-wham-shaped `usage_history` rows (and
   `fable`/`haiku` `probe_snapshots`) back to the Anthropic org id and
   re-importing a valid token
+- **Healing migration merges duplicate provider accounts sharing an email.**
+  `10660f3` only stopped a *fresh* `codex import` from forking a second row for
+  an OpenAI account whose original row predated the native-id era (keyed by a
+  locally generated UUID); a database where the duplicate already existed kept
+  both rows polling the same account independently. At launch, account pairs
+  sharing `(email, provider)` are now merged automatically: history moves onto
+  the surviving row (preferring the provider-native id), exactly one
+  credential survives (the more recently renewed of the two), and the sibling
+  row is removed. Idempotent, and covered by a selftest over a scratch DB (#45)
 
 ## [1.18.0] - 2026-07-30
 

--- a/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
+++ b/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
@@ -54,6 +54,7 @@ enum SelfTest {
         testNamedLimitsRoundTrip()
         testOpenAIImportResolvesExistingAccountByEmail()
         testAccountSyncImportIsProviderScoped()
+        testMergeDuplicateAccountsSharingEmail()
 
         if let idx = arguments.firstIndex(of: "--db"), idx + 1 < arguments.count {
             testMigrationOfExistingDatabase(at: arguments[idx + 1])
@@ -674,6 +675,144 @@ enum SelfTest {
         } catch {
             checks += 1
             failures.append("account sync provider scoping test threw: \(error)")
+        }
+    }
+
+    // MARK: - Duplicate account merge (#45)
+
+    /// A database created before `10660f3` (v1.18.0) can carry two active
+    /// rows for the same account — one keyed by a locally generated UUID
+    /// from the pre-native-id era, one by the provider's native id — each
+    /// polled independently. The healing migration must merge them: history
+    /// moves onto the surviving (native-id) row, exactly one credential
+    /// survives (the more recently renewed of the two), the settings pin
+    /// follows if it pointed at the row being removed, an Anthropic row
+    /// sharing the same email is left untouched (provider-scoped), and a
+    /// second run over the healed database is a no-op.
+    private static func testMergeDuplicateAccountsSharingEmail() {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("claude-monitor-selftest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let dbPath = dir.appendingPathComponent("usage.db").path
+
+            let store = UsageStore(dbPath: dbPath)
+            store.ensureDatabase()
+            let db = try openDatabase(dbPath)
+
+            let legacyId = "BFA6C1F0-8C2A-4CB0-9A5E-000000000001" // canonical UUID shape
+            let nativeId = "user-native-oai"
+
+            try db.run("""
+                INSERT INTO accounts (id, account_name, email, plan, last_updated, provider)
+                VALUES (?, 'me@example.com', 'me@example.com', 'pro', '2026-01-01T00:00:00Z', 'openai')
+            """, legacyId)
+            try db.run("""
+                INSERT INTO accounts (id, account_name, email, plan, last_updated, provider)
+                VALUES (?, 'me@example.com', 'me@example.com', 'pro', '2026-06-01T00:00:00Z', 'openai')
+            """, nativeId)
+            // Shares the email but a different provider — must survive untouched.
+            try db.run("""
+                INSERT INTO accounts (id, account_name, email, plan, last_updated, provider)
+                VALUES ('anthropic-row', 'me@example.com', 'me@example.com', 'Max',
+                        '2026-01-01T00:00:00Z', 'anthropic')
+            """)
+
+            try db.run("""
+                INSERT INTO usage_history (account_id, timestamp, primary_percent, is_synthetic)
+                VALUES (?, '2026-01-01T00:00:00Z', 10, 0)
+            """, legacyId)
+            try db.run("""
+                INSERT INTO usage_history (account_id, timestamp, primary_percent, is_synthetic)
+                VALUES (?, '2026-06-01T00:00:00Z', 20, 0)
+            """, nativeId)
+            try db.run("""
+                INSERT INTO probe_snapshots (account_id, timestamp, probe_model, http_status, headers)
+                VALUES (?, '2026-01-01T00:00:00Z', 'haiku', 200, '{}')
+            """, legacyId)
+            // named_limits only exists for the legacy row — merge must carry it
+            // over even though the native row never had any.
+            try db.run("""
+                INSERT INTO named_limits (account_id, timestamp, limit_name, used_percent)
+                VALUES (?, '2026-01-01T00:00:00Z', 'GPT-5.3-Codex-Spark', 42)
+            """, legacyId)
+
+            // The legacy row's credential was renewed more recently than the
+            // native row's — the merge must keep the legacy credential's
+            // token even though the *native* row is the id that survives.
+            try db.run("""
+                INSERT INTO oauth_credentials
+                    (account_id, label, source, provider, access_token, is_active,
+                     created_at, updated_at, token_rolled_at)
+                VALUES (?, 'me@example.com', 'codex', 'openai', 'legacy-fresher-token', 1,
+                        '2026-01-01T00:00:00Z', '2026-06-20T00:00:00Z', '2026-06-20T00:00:00Z')
+            """, legacyId)
+            try db.run("""
+                INSERT INTO oauth_credentials
+                    (account_id, label, source, provider, access_token, is_active,
+                     created_at, updated_at, token_rolled_at)
+                VALUES (?, 'me@example.com', 'codex', 'openai', 'native-stale-token', 1,
+                        '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z', '2026-01-05T00:00:00Z')
+            """, nativeId)
+
+            // The user had pinned the legacy row as their primary account.
+            try db.run("INSERT INTO settings (key, value) VALUES ('primary_account_id', ?)", legacyId)
+
+            // --- What the next launch does. ---
+            store.ensureDatabase()
+
+            let openaiRows = try db.prepare(
+                "SELECT id FROM accounts WHERE email = 'me@example.com' AND provider = 'openai'"
+            ).map { $0[0] as? String }
+            expectEqual(openaiRows.count, 1, "the openai duplicate pair merges into one row")
+            expectEqual(openaiRows.first.flatMap { $0 } ?? "", nativeId,
+                        "the provider-native id survives over the locally generated UUID")
+
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM accounts WHERE id = ?", legacyId) as? Int64, 0,
+                "the losing row is removed")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM accounts WHERE email = 'me@example.com'") as? Int64, 2,
+                "the anthropic row sharing the email is untouched (provider-scoped)")
+            expectEqual(
+                try db.scalar("SELECT provider FROM accounts WHERE id = 'anthropic-row'") as? String,
+                "anthropic", "the anthropic row keeps its provider")
+
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM usage_history WHERE account_id = ?", nativeId) as? Int64, 2,
+                "usage_history rows from both accounts land on the survivor")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM probe_snapshots WHERE account_id = ?", nativeId) as? Int64, 1,
+                "probe_snapshots rows move onto the survivor")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM named_limits WHERE account_id = ?", nativeId) as? Int64, 1,
+                "named_limits rows move onto the survivor even though the survivor never had any")
+
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM oauth_credentials WHERE account_id IN (?, ?)",
+                              nativeId, legacyId) as? Int64,
+                1, "exactly one credential survives the merge")
+            expectEqual(
+                try db.scalar("SELECT access_token FROM oauth_credentials WHERE account_id = ?", nativeId) as? String,
+                "legacy-fresher-token",
+                "the more recently renewed credential wins, reassigned to the survivor")
+
+            expectEqual(
+                try db.scalar("SELECT value FROM settings WHERE key = 'primary_account_id'") as? String,
+                nativeId, "the primary-account pin follows the merge to the survivor")
+
+            // Idempotent: re-running over an already-healed database changes nothing.
+            store.ensureDatabase()
+            expectEqual(try db.scalar("SELECT COUNT(*) FROM accounts") as? Int64, 2,
+                        "re-running the healed database doesn't merge or remove anything further")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM oauth_credentials WHERE account_id IN (?, ?)",
+                              nativeId, legacyId) as? Int64,
+                1, "re-running doesn't touch the surviving credential")
+        } catch {
+            checks += 1
+            failures.append("duplicate account merge test threw: \(error)")
         }
     }
 

--- a/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
@@ -388,6 +388,16 @@ class UsageStore: ObservableObject {
         // loom-daemon's `tokens import-from-monitor`) key accounts on, so an
         // account must never persist indefinitely without one (#15).
         backfillMissingEmailsFromAccountName(db)
+
+        // Migration: merge account rows left duplicated by pre-1.18.1
+        // databases. `10660f3` stops a fresh `codex import` from creating a
+        // second row for an OpenAI account whose original row predated the
+        // native-id era (keyed by a locally generated UUID rather than
+        // OpenAI's `user-…` id) — that fix is prevention only, so any
+        // database where the duplicate already exists still has two active
+        // rows polling the same account independently (#45). Must run after
+        // the email backfill above so a row healed there is eligible too.
+        mergeDuplicateAccountsSharingEmail(db)
     }
 
     /// Adds a column only when it isn't already there. `ALTER TABLE ... ADD
@@ -430,6 +440,116 @@ class UsageStore: ObservableObject {
             }
         } catch {
             FileLogger.shared.error("backfillMissingEmailsFromAccountName failed: \(error)", category: "DB")
+        }
+    }
+
+    /// One-time-per-launch healing pass (#45): merges account rows that
+    /// share the same `(email, provider)` pair. Matching is provider-scoped
+    /// so a Claude and a ChatGPT account under one address never merge —
+    /// same guard `resolveOpenAIAccountId` and `AccountSync.importAccount`
+    /// already apply. Idempotent: once only one row remains per (email,
+    /// provider), the grouping query below finds nothing to merge.
+    private static func mergeDuplicateAccountsSharingEmail(_ db: Connection) {
+        struct Candidate {
+            let id: String
+            let provider: String
+            let email: String
+            let lastUpdated: String?
+        }
+        do {
+            let stmt = try db.prepare("""
+                SELECT id, COALESCE(provider, 'anthropic'), email, last_updated
+                FROM accounts
+                WHERE email IS NOT NULL AND TRIM(email) != ''
+            """)
+            var candidates: [Candidate] = []
+            for row in stmt {
+                guard let id = row[0] as? String,
+                      let provider = row[1] as? String,
+                      let email = row[2] as? String else { continue }
+                candidates.append(Candidate(id: id, provider: provider, email: email, lastUpdated: row[3] as? String))
+            }
+
+            // Group key uses a separator that cannot appear in either field
+            // (both come from the accounts table, never user-typed free
+            // text) so an email/provider pair can't collide with another.
+            let groups = Dictionary(grouping: candidates) { "\($0.email)\u{0}\($0.provider)" }
+            for (_, group) in groups where group.count > 1 {
+                let survivorId = pickMergeSurvivor(group.map { (id: $0.id, lastUpdated: $0.lastUpdated) })
+                for candidate in group where candidate.id != survivorId {
+                    mergeAccountRow(db, from: candidate.id, into: survivorId)
+                }
+            }
+        } catch {
+            FileLogger.shared.error("mergeDuplicateAccountsSharingEmail failed: \(error)", category: "DB")
+        }
+    }
+
+    /// Picks which of a set of duplicate `(email, provider)` rows survives a
+    /// merge. Prefers a provider-native id (one that doesn't parse as a
+    /// canonical UUID — the shape Swift's `UUID()` produces for a locally
+    /// generated id, and the shape the pre-native-id-era duplicate is keyed
+    /// by) over a generated one; ties — including when every candidate looks
+    /// native, or none does — break on the most-recently-updated row.
+    private static func pickMergeSurvivor(_ candidates: [(id: String, lastUpdated: String?)]) -> String {
+        let native = candidates.filter { UUID(uuidString: $0.id) == nil }
+        let pool = native.isEmpty ? candidates : native
+        return pool.max { ($0.lastUpdated ?? "") < ($1.lastUpdated ?? "") }?.id ?? candidates[0].id
+    }
+
+    /// Merges `loserId`'s history, credential, and settings pin onto
+    /// `survivorId`, then removes the now-empty `loserId` row. Runs inside a
+    /// transaction so a mid-merge failure never leaves history split across
+    /// two rows with neither id complete.
+    private static func mergeAccountRow(_ db: Connection, from loserId: String, into survivorId: String) {
+        do {
+            try db.execute("BEGIN")
+            try db.run("UPDATE usage_history SET account_id = ? WHERE account_id = ?", survivorId, loserId)
+            try db.run("UPDATE probe_snapshots SET account_id = ? WHERE account_id = ?", survivorId, loserId)
+            try db.run("UPDATE named_limits SET account_id = ? WHERE account_id = ?", survivorId, loserId)
+
+            // Exactly one credential survives: the most recently renewed
+            // between the two rows (falling back to updated_at for a
+            // credential that has never been rolled). Any other credential
+            // row for either id is discarded rather than merged — a stale
+            // token for an account that already has a fresher one is not
+            // useful to keep around.
+            var winnerCredentialId: Int64?
+            let credStmt = try db.prepare("""
+                SELECT id FROM oauth_credentials
+                WHERE account_id IN (?, ?)
+                ORDER BY COALESCE(token_rolled_at, updated_at) DESC
+                LIMIT 1
+            """)
+            for row in credStmt.bind(survivorId, loserId) {
+                winnerCredentialId = row[0] as? Int64
+            }
+            if let winnerCredentialId {
+                try db.run("UPDATE oauth_credentials SET account_id = ? WHERE id = ?",
+                           survivorId, winnerCredentialId)
+                try db.run("DELETE FROM oauth_credentials WHERE account_id IN (?, ?) AND id != ?",
+                           survivorId, loserId, winnerCredentialId)
+            } else {
+                try db.run("DELETE FROM oauth_credentials WHERE account_id = ?", loserId)
+            }
+
+            // The user's pinned "primary" account (if it was the row being
+            // removed) must keep pointing at a live account after the merge.
+            try db.run("UPDATE settings SET value = ? WHERE key = ? AND value = ?",
+                       survivorId, primaryAccountSettingKey, loserId)
+
+            try db.run("DELETE FROM accounts WHERE id = ?", loserId)
+            try db.execute("COMMIT")
+            FileLogger.shared.info(
+                "mergeDuplicateAccountsSharingEmail: merged \(loserId) into \(survivorId)",
+                category: "DB"
+            )
+        } catch {
+            try? db.execute("ROLLBACK")
+            FileLogger.shared.error(
+                "mergeDuplicateAccountsSharingEmail: merge of \(loserId) into \(survivorId) failed: \(error)",
+                category: "DB"
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

- `10660f3` (v1.18.0) stopped a **fresh** `codex import` from forking a duplicate account row for an OpenAI account whose original row predated the native-id era (keyed by a locally generated UUID). That fix is prevention only — a database where the duplicate already exists keeps both rows polling the same account independently, each with its own credential.
- Adds a one-time-per-launch healing migration, following the existing `#23` `email=NULL` healing pattern in `UsageStore.applySchema`: account pairs sharing `(email, provider)` are merged into one surviving row.

## Changes

- `menubar-app/ClaudeMonitor/Sources/UsageStore.swift`: `mergeDuplicateAccountsSharingEmail(_:)`, called from `applySchema` after the email backfill. For each `(email, provider)` group with more than one row:
  - `pickMergeSurvivor` prefers a provider-native id (one that doesn't parse as a canonical UUID — the shape Swift's `UUID()` produces, and the shape the pre-native-id-era duplicate is keyed by) over a locally generated one; ties break on the most-recently-updated row.
  - `mergeAccountRow` moves `usage_history`, `probe_snapshots`, and `named_limits` rows onto the survivor, keeps exactly one `oauth_credentials` row (the more recently renewed of the pair, by `COALESCE(token_rolled_at, updated_at)`), repoints the `primary_account_id` settings pin if it followed the row being removed, and deletes the losing account row — all inside a transaction so a mid-merge failure can't split history across two rows.
- `menubar-app/ClaudeMonitor/Sources/SelfTest.swift`: `testMergeDuplicateAccountsSharingEmail()` over a scratch DB — covers the merge itself, provider-scoping (an Anthropic row sharing the email is untouched), the credential-recency tie-break, the settings pin repoint, and idempotency (re-running the healed DB is a no-op).
- `CHANGELOG.md`: entry under the current `[1.18.1]` section (matching how `10660f3` recorded its fix), following this repo's existing practice of appending to the latest section between releases.

## Acceptance Criteria Verification

- [x] One-time healing migration at launch, same pattern as the `#23` `email=NULL` healing — `mergeDuplicateAccountsSharingEmail` runs unconditionally from `UsageStore.applySchema`, called by `ensureDatabase()` on every launch.
- [x] `usage_history`, `probe_snapshots`, `named_limits` merged onto one surviving row; provider-native id preferred when one of the pair has it — verified by `testMergeDuplicateAccountsSharingEmail`.
- [x] Exactly one credential survives (most recently renewed); sibling row and its credential removed — verified (`legacy-fresher-token` wins over a newer-id row with a staler `token_rolled_at`).
- [x] Idempotent: re-running on a healed DB is a no-op — verified by a second `ensureDatabase()` call in the test asserting unchanged row counts.
- [x] Covered by a selftest over a scratch DB — `testMergeDuplicateAccountsSharingEmail`, registered in `SelfTest.main`.

## Test Plan

- `swift build && .build/debug/ClaudeMonitor selftest` — `selftest: 139 check(s) passed` (was 138 before this change; +1 new test).
- Linux build verified via the `swift:6.1` Docker image (`apt-get install libsqlite3-dev`, `swift build`, `selftest`) — build succeeds, all 139 checks pass.
- `swift build -Xswiftc -swift-version -Xswiftc 6` (the stronger local proxy for CI's strict-concurrency checks) was run — it reports the same pre-existing Swift-6-language-mode errors already present on `main` (unrelated `FileLogger`/`UpdateChecker`/`SelfTest` static-state warnings across the codebase, confirmed identical error count on `main` before this change), so this is not a regression introduced here.

Closes #45