### PR TITLE
Order capped accounts by time until they are usable again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spent, the session reset otherwise. The same rule replaces the old
   session-reset-first tiebreak used for popover ordering and the auto-selected
   menubar account.
+- **`npm test` runs the self-test.** The script still claimed there was no test
+  target and exited 0 unconditionally, which predates `selftest` — orchestration
+  gates that shell out to it now actually gate.
 
 ## [1.18.3] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Capped accounts sort by when they come back.** Accounts tied on headroom —
+  in practice the block of exhausted accounts all reading 0% — now order by time
+  until the reset that actually gates them: the weekly reset once the week is
+  spent, the session reset otherwise. The same rule replaces the old
+  session-reset-first tiebreak used for popover ordering and the auto-selected
+  menubar account.
+
 ## [1.18.3] - 2026-08-02
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -342,7 +342,9 @@ swift build
 .build/debug/ClaudeMonitor &
 ```
 
-CI (`.github/workflows/build.yml`) runs the same `swift build` on every push.
+CI (`.github/workflows/build.yml`) runs on pushes to `main` and on pull requests:
+two jobs build the package — macOS and a `swift:6.1` Linux container — and each
+runs `ClaudeMonitor selftest`, with the Linux job also smoke-running `--once`.
 
 ### Build for Distribution
 
@@ -651,13 +653,14 @@ claude-monitor/
 │   ├── build-macos-app.sh          # macOS release build script
 │   └── claude-monitor.service      # Sample systemd user unit for Linux headless mode
 ├── docs/spikes/                 # Investigation write-ups (e.g. the OpenAI usage-endpoint probe)
-├── .github/workflows/build.yml  # CI: swift build on push
+├── .github/workflows/build.yml  # CI: build + selftest on macOS and Linux
 ├── build/                       # Build output (gitignored): ClaudeMonitor.app + .zip
-├── CHANGELOG.md
+├── CHANGELOG.md                 # Release history
+├── CLAUDE.md                    # Development notes (build/install sequence, invariants)
 ├── .env.example                 # Sample accounts.env for bulk import
 ├── window.png, plot_window.png  # README screenshots
 ├── loom.sh, package.json        # Loom orchestration workspace files (not part of the app)
-└── .loom/, .claude/             # Loom + Claude Code tooling installs
+└── .loom/, .claude/, .gitattributes  # Loom + Claude Code tooling installs
 ```
 
 ## Related Projects

--- a/menubar-app/ClaudeMonitor/Sources/RateLimitWindow.swift
+++ b/menubar-app/ClaudeMonitor/Sources/RateLimitWindow.swift
@@ -260,4 +260,22 @@ struct RateLimitSnapshot {
     var nextReset: Date? {
         [session?.resetAt, weekly?.resetAt].compactMap { $0 }.min()
     }
+
+    /// The window whose reset actually gates this account's next usable moment.
+    ///
+    /// An exhausted weekly window is the gate: the session limit rolling over in
+    /// twenty minutes buys nothing while the week is spent. Otherwise the
+    /// session window is what frees up first, and an account with no session
+    /// window (an OpenAI reading may have none) falls back to its weekly one.
+    var gatingWindow: RateLimitWindow? {
+        if let weekly = weekly, weekly.isExhausted { return weekly }
+        return session ?? weekly
+    }
+
+    /// Seconds until this account is expected to have capacity again, measured
+    /// against `gatingWindow`. Nil when no relevant reset time is known — so
+    /// callers rank it as *unknown* rather than *imminent*.
+    var secondsUntilRecovery: TimeInterval? {
+        gatingWindow?.resetAt?.timeIntervalSinceNow
+    }
 }

--- a/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
+++ b/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
@@ -52,6 +52,7 @@ enum SelfTest {
 
         testNaturalSort()
         testSortedAccountsForPopoverTieBreak()
+        testGatingResetOrdering()
         testWindowKindDerivation()
         testSnapshotFromPositionalWindows()
         testMissingSessionWindow()
@@ -144,6 +145,60 @@ enum SelfTest {
         let ordered = store.sortedAccountsForPopover.map { $0.displayName }
         expectEqual(ordered, ["agent-9", "agent-10"],
                     "equal usage/reset falls back to natural name order, not account id")
+    }
+
+    /// Accounts that are all capped (0 headroom) still have a meaningful order:
+    /// whichever comes back first. The gating reset is the weekly one once the
+    /// week is spent, so an account with a session reset minutes away but no
+    /// weekly capacity must rank *behind* one whose session reset is hours out.
+    private static func testGatingResetOrdering() {
+        func iso(_ seconds: TimeInterval) -> String {
+            ISO8601DateFormatter().string(from: Date().addingTimeInterval(seconds))
+        }
+        func capped(_ accountId: String, weekly: Double, session: TimeInterval, weeklyReset: TimeInterval)
+            -> UsageRecord {
+            UsageRecord(
+                id: 1, accountId: accountId, timestamp: Date(),
+                primaryPercent: 100, sessionPercent: 100, weeklyAllPercent: weekly,
+                weeklySONnetPercent: nil,
+                sessionReset: iso(session), weeklyReset: iso(weeklyReset)
+            )
+        }
+
+        // Session-capped with weekly capacity left → the session reset gates.
+        let sessionGated = capped("a", weekly: 40, session: 7200, weeklyReset: 3 * 86400)
+        expect((sessionGated.rateLimit.secondsUntilRecovery ?? 0) > 7000,
+               "session-capped account recovers at its session reset")
+        expect((sessionGated.rateLimit.secondsUntilRecovery ?? .infinity) < 7300,
+               "session-gated recovery must not read the weekly reset")
+
+        // Weekly spent → the session reset is irrelevant; the week gates.
+        let weeklyGated = capped("b", weekly: 100, session: 600, weeklyReset: 3 * 86400)
+        expect((weeklyGated.rateLimit.secondsUntilRecovery ?? 0) > 2 * 86400,
+               "an exhausted weekly window gates recovery, not the session reset")
+
+        // Nothing known → unknown, never "available now".
+        let empty = UsageRecord(
+            id: 2, accountId: "c", timestamp: Date(),
+            primaryPercent: nil, sessionPercent: nil, weeklyAllPercent: nil,
+            weeklySONnetPercent: nil, sessionReset: nil, weeklyReset: nil
+        )
+        expect(empty.rateLimit.secondsUntilRecovery == nil, "no windows → unknown recovery")
+
+        let store = UsageStore(dbPath: ":memory:selftest-gating")
+        func account(_ name: String) -> Account {
+            Account(id: name, accountName: name, email: nil, plan: "Max",
+                    lastUpdated: nil, latestPercent: nil)
+        }
+        store.accounts = ["agent-1", "agent-2", "agent-3"].map(account)
+        store.latestUsage = [
+            "agent-1": capped("agent-1", weekly: 40, session: 7200, weeklyReset: 3 * 86400),
+            "agent-2": capped("agent-2", weekly: 100, session: 600, weeklyReset: 3 * 86400),
+            "agent-3": capped("agent-3", weekly: 10, session: 1800, weeklyReset: 3 * 86400),
+        ]
+        expectEqual(store.sortedAccountsForPopover.map { $0.displayName },
+                    ["agent-3", "agent-1", "agent-2"],
+                    "capped accounts order by time until they are usable again")
     }
 
     // MARK: - Window model

--- a/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
@@ -402,8 +402,30 @@ struct UsagePopoverView: View {
         case (nil, _):   return false          // nil rows go last
         case (_, nil):   return true
         case let (.some(x), .some(y)):
-            if x == y { return stableTiebreak(a.0, b.0) }
-            return sortDir == .asc ? (x < y) : (x > y)
+            if x != y { return sortDir == .asc ? (x < y) : (x > y) }
+            if case .headroom = sortBy, let ordered = recoveryTiebreak(a.1, b.1) { return ordered }
+            return stableTiebreak(a.0, b.0)
+        }
+    }
+
+    /// Tiebreak for the Headroom column. Equal scores are the norm at the
+    /// bottom of the table, where every capped account reads 0 — so order those
+    /// by how soon they come back. The gating reset is the weekly one once the
+    /// week is spent, and the session one otherwise: a session window rolling
+    /// over in minutes means nothing to an account that is out for the week.
+    ///
+    /// Returns nil when the two rows are indistinguishable (equal or both
+    /// unknown), leaving the caller to fall through to the name tiebreak.
+    private func recoveryTiebreak(_ a: UsageRecord?, _ b: UsageRecord?) -> Bool? {
+        switch (a?.rateLimit.secondsUntilRecovery, b?.rateLimit.secondsUntilRecovery) {
+        case (nil, nil): return nil
+        case (nil, _):   return false          // unknown recovery goes last
+        case (_, nil):   return true
+        case let (.some(x), .some(y)):
+            if x == y { return nil }
+            // Coming back sooner is the better row, so it leads under the
+            // "best first" direction and trails when the sort is flipped.
+            return sortDir == .desc ? (x < y) : (x > y)
         }
     }
 

--- a/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
@@ -569,17 +569,14 @@ class UsageStore: ObservableObject {
         }
     }
 
-    /// Seconds until reset (session first, then weekly). Returns large value if
-    /// unknown — including when the provider reports no window at all.
+    /// Seconds until the account has capacity again — the reset of whichever
+    /// window is actually gating it (weekly when the week is spent, otherwise
+    /// session). Returns a large value if unknown — including when the provider
+    /// reports no window at all — so unknowns rank last rather than first.
     // Pure function of its argument — touches no instance/class main-actor
     // state.
     nonisolated static func resetSeconds(_ usage: UsageRecord?) -> TimeInterval {
-        guard let usage = usage else { return .greatestFiniteMagnitude }
-        let snapshot = usage.rateLimit
-        for date in [snapshot.session?.resetAt, snapshot.weekly?.resetAt].compactMap({ $0 }) {
-            return date.timeIntervalSinceNow
-        }
-        return .greatestFiniteMagnitude
+        usage?.rateLimit.secondsUntilRecovery ?? .greatestFiniteMagnitude
     }
 
     /// Account ID currently driving the menubar icon. Falls back to the

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "worktree:return": "./.loom/scripts/worktree-return.sh",
     "check:ci": "cd menubar-app/ClaudeMonitor && swift build",
     "check:all": "npm run check:ci && npm run test",
-    "test": "echo 'No Swift test target: menubar-app/ClaudeMonitor/Package.swift defines only the ClaudeMonitor executable target, no Tests/ directory. Correctness is verified by check:ci (swift build) plus the .github/workflows/build.yml CI build.' && exit 0",
+    "test": "cd menubar-app/ClaudeMonitor && swift build && .build/debug/ClaudeMonitor selftest",
     "lint": "echo 'No linter configured. Customize this script for your project.' && exit 0"
   }
 }


### PR DESCRIPTION
## What

When sorting by Headroom, every exhausted account reads 0 — so the whole capped block fell through to the display-name tiebreak, and the account coming back in ten minutes sorted next to one that is out for three days.

Ties on the Headroom column now break on the reset that **actually gates** the account:

- weekly window exhausted (100% used, or the provider says `rejected`) → the **weekly** reset gates it
- otherwise → the **session** reset gates it
- no session window at all (an OpenAI reading may have none) → falls back to weekly
- no reset time known → stays `nil` and ranks last, rather than reading as "available now"

## Where it applies

`RateLimitSnapshot` gains `gatingWindow` / `secondsUntilRecovery` in the portable core, so the headless Linux daemon reasons about recovery the same way the popover does.

`UsageStore.resetSeconds` always preferred the session reset; it is now a thin wrapper over `secondsUntilRecovery`. That fixes the identical flaw in `sortedAccountsForPopover`, and therefore in the auto-picked menubar account — an account with a session reset ten minutes out but no weekly capacity used to outrank one that was genuinely two hours from usable.

The popover tiebreak respects sort direction, so flipping the header inverts the recovery order too instead of pinning one end of it.

## Verification

- `swift build` clean under the Swift 6 language mode adopted in #53
- `selftest` passes 144 checks; `testGatingResetOrdering` covers the three gating cases directly, then orders three capped accounts end-to-end through `sortedAccountsForPopover`
- The end-to-end case gives the weekly-exhausted account the **soonest** session reset on purpose, so a regression to the old behavior sorts it first and fails
- Mutation-checked: deleting the weekly-gating line fails exactly those two assertions and nothing else

## Second commit (unrelated, repo hygiene)

`npm test` claimed there was no Swift test target and exited 0 unconditionally — that predates `selftest`, which CI has run on both platforms since #30, so every orchestration gate shelling out to `npm run test` / `check:all` was passing vacuously. It now builds and runs the suite. Also corrects the README's CI description (two jobs, both running selftest) and adds the missing `CLAUDE.md` to the project tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)