### PR TITLE
docs: supersede the Codex spike — app-server replaces stored OAuth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,20 @@ What differs from an Anthropic row once it's added:
 >   `accounts export` → `accounts import` (see
 >   [Multi-host sync](#multi-host-sync)),
 >   or just re-run `codex import` there after a fresh `codex login`.
+>
+> **This re-sync loop does not converge, and is being replaced.** Each holder
+> of the credential — this app on host A, this app on host B, the Codex CLI on
+> each of them — invalidates the others when it renews, so re-syncing only
+> moves which one is about to break next. Observed in practice: continuous
+> `401 / refresh_token_invalidated` across two hosts for ~9 days, while the
+> accounts themselves stayed healthy and a current `codex` read their usage
+> immediately. OpenAI's own guidance is that an `auth.json` is single-machine
+> and must not be shared across hosts, so **do not** copy OpenAI credentials
+> between machines; register the account on each host instead. The fix is to
+> stop holding the credential at all and read usage via `codex app-server`,
+> which owns its own auth — see #102, #103 and #104, and the 2026-08-15
+> supersession in
+> [`docs/spikes/2026-07-30-codex-usage-probe.md`](docs/spikes/2026-07-30-codex-usage-probe.md).
 
 ### Rolling a Token (revoke + re-mint)
 

--- a/docs/spikes/2026-07-30-codex-usage-probe.md
+++ b/docs/spikes/2026-07-30-codex-usage-probe.md
@@ -235,7 +235,13 @@ and `Account` schema now — in particular:
   correct without that check — treat it as a strong hypothesis, not a
   verified contract.
 
-## Live verification (2026-07-30) — AUTHORITATIVE
+## Live verification (2026-07-30) — AUTHORITATIVE for the wire contract
+
+> **Partly superseded.** This section's *wire contract* is still correct and is
+> now the fallback path. Its *design* conclusion — store and refresh a
+> credential — was reversed on 2026-08-15; see
+> [Supersession (2026-08-15)](#supersession-2026-08-15--rotation-confirmed-app-server-is-the-supported-surface)
+> at the end of this document before designing against anything here.
 
 The operator judged a disposable account unnecessary: the probe is a
 **read-only GET** against the same endpoint Codex CLI's own `/usage` command

--- a/docs/spikes/2026-07-30-codex-usage-probe.md
+++ b/docs/spikes/2026-07-30-codex-usage-probe.md
@@ -362,6 +362,97 @@ What this establishes, and what it doesn't:
   actually in use. Re-confirmed on 2026-07-30: still `null` on this Pro
   account, with a weekly `primary_window` at 14%.
 
+## Supersession (2026-08-15) — rotation confirmed; `app-server` is the supported surface
+
+Two of the "Still unverified" items above are now settled, and one of them
+inverts this spike's central design recommendation. **This section is
+authoritative where it disagrees with anything above it, including the
+2026-07-30 live verification.**
+
+### 1. OpenAI *does* rotate refresh tokens for this client
+
+The spike deliberately never ran a successful refresh exchange, so rotation
+stayed open here — and the recommendation above ("treat `refresh_token`-based
+renewal as mandatory infrastructure", store `refresh_token` +
+`token_expires_at`) was written without the answer, then built on and shipped.
+Rotation was confirmed shortly afterwards and is documented in the README's
+"Note on refresh-token rotation" (verified 2026-07-31); this section records
+what the *consequences* turned out to be in sustained multi-host use, which is
+what invalidates the design rather than the bare fact of rotation.
+
+Because the app kept its own copy of a rotating credential, its copy and the
+Codex CLI's own `$CODEX_HOME/auth.json` invalidated each other in turn.
+Observed in production: continuous `401 / refresh_token_invalidated` on every
+poll across two hosts for ~9 days, with every `provider: openai` row frozen —
+while the **accounts themselves were entirely healthy**. Running a current
+`codex` refreshed `auth.json` in place and returned live usage immediately.
+Only the stored snapshot was dead. The app was reporting its own staleness as
+an account failure.
+
+OpenAI states the constraint directly:
+
+> Use one `auth.json` per runner or per serialized workflow stream. Do not
+> share the same file across concurrent jobs or multiple machines.
+> — <https://learn.chatgpt.com/docs/auth/ci-cd-auth>
+
+The design conclusion therefore inverts: this app should **not** store,
+refresh, or sync an OpenAI credential at all. `accounts export` carrying one
+between machines is guaranteed to break the source host.
+
+### 2. `codex app-server` returns usage directly, with Codex owning the credential
+
+There is a supported surface that needs no credential handling from us at all.
+`codex -s read-only -a untrusted app-server` speaks JSON-RPC over stdio:
+
+```
+initialize → initialized (notification) → account/read → account/rateLimits/read
+```
+
+`account/read` returns account type, email and plan. `account/rateLimits/read`
+returns (values redacted):
+
+```jsonc
+{"rateLimits": {
+   "limitId": "codex",
+   "primary": {"usedPercent": <n>, "windowDurationMins": 10080, "resetsAt": <epoch>},
+   "secondary": null,
+   "credits": {"hasCredits": false, "unlimited": false, "balance": "<n>"},
+   "planType": "<plan>"},
+ "rateLimitsByLimitId": {"codex": {…},
+   "codex_bengalfox": {"limitName": "GPT-5.3-Codex-Spark", "primary": {…}}},
+ "rateLimitResetCredits": {"availableCount": 0, "credits": []}}
+```
+
+Note `windowDurationMins` here versus `limit_window_seconds` on the `wham`
+wire contract — same quantity, different unit and name.
+
+`CODEX_HOME` scopes this per account, which is also the answer to multi-account
+support: `codex login` writes one `auth.json` per home, so each login clobbers
+the previous account. An unauthenticated home answers `account/read` cleanly
+with `{"account": null, "requiresOpenaiAuth": true}` rather than failing, which
+gives a per-account "needs login" signal.
+
+### 3. Version constraint
+
+`account/rateLimits/read` does **not** exist in codex 0.46.0 — it returns
+`-32600 Invalid request`. Verified working on 0.147.0. Homebrew's formula lags
+well behind the npm `@openai/codex` channel, and `app-server` is marked
+`[experimental]` with method names that have already changed between versions,
+so a client must probe for capability rather than assume it.
+
+### What above is still binding
+
+The live-verification section's `wham/usage` contract is unchanged and remains
+correct — it is now the **fallback** path, to be called with a bearer token
+read from `auth.json` at request time and never stored. Both of its "genuinely
+new findings" also survive intact and are reinforced by the `app-server` shape:
+window kind must be derived from the window's duration rather than its
+position, a session window may legitimately be absent (`secondary: null`), and
+per-model sub-limits are first-class.
+
+Tracked in #102 (app-server client), #103 (per-account `CODEX_HOME`), #104
+(retire stored OpenAI tokens).
+
 ## References
 
 - Codex CLI: `codex-cli 0.146.0`, installed via `brew install --cask codex`

--- a/docs/spikes/README.md
+++ b/docs/spikes/README.md
@@ -20,19 +20,27 @@ Conventions:
 
 | Spike | Question | Outcome |
 |-------|----------|---------|
-| [2026-07-30-codex-usage-probe.md](2026-07-30-codex-usage-probe.md) | Can a cheap authenticated probe read ChatGPT/Codex subscription usage and rate-limit windows? | **Yes.** `GET chatgpt.com/backend-api/wham/usage` with the Codex bearer token. |
+| [2026-07-30-codex-usage-probe.md](2026-07-30-codex-usage-probe.md) | Can a cheap authenticated probe read ChatGPT/Codex subscription usage and rate-limit windows? | **Yes**, but not the way the spike concluded — see the 2026-08-15 supersession. `codex app-server` is the supported surface; `GET wham/usage` is the fallback. |
 
 ### Reading the Codex probe write-up
 
-That document has two layers, and only the second is binding. It opens with
+That document has three layers, and only the last is binding. It opens with
 static analysis of the Codex CLI binary, which produced a plausible but
-**wrong** guess at the wire format. The later "Live verification
-(AUTHORITATIVE)" section records what a real request returned and corrects it —
-different field names, a different route, and the discovery that a session
-window may legitimately be absent.
+**wrong** guess at the wire format. The "Live verification (AUTHORITATIVE)"
+section records what a real request returned and corrects it — different field
+names, a different route, and the discovery that a session window may
+legitimately be absent.
 
-Design against the live-verification section. `OpenAIAPI.swift` and
-`RateLimitWindow.swift` both cite it.
+The **2026-08-15 supersession** at the end then reverses the spike's central
+*design* recommendation. The spike never ran a successful token refresh, so it
+could not tell that OpenAI rotates refresh tokens; it recommended storing and
+refreshing one anyway, and that shipped and broke — a stored copy and the Codex
+CLI's own `auth.json` invalidate each other in turn. The app should hold no
+OpenAI credential at all, and read usage over `codex app-server` instead.
+
+Design against the supersession section. `OpenAIAPI.swift` and
+`RateLimitWindow.swift` still cite the live-verification section, which remains
+correct as the fallback wire contract.
 
 `codex-usage-probe.sh` beside it is runnable: it prints only status codes and
 redacted field names, never token values.


### PR DESCRIPTION
## Summary

Docs-only. Brings the Codex design documentation in line with what was actually
verified this week, and marks the superseded recommendation as superseded
rather than deleting it — following the convention `docs/spikes/README.md`
states for exactly this case.

The 2026-07-30 spike recommended storing an OpenAI `refresh_token` +
`token_expires_at` and renewing proactively. It deliberately never ran a
successful refresh exchange, so it could not tell that OpenAI rotates the
refresh token on every use. That design shipped, and it does not hold: every
holder of the credential — this app on either host, plus the Codex CLI's own
`$CODEX_HOME/auth.json` — invalidates the others when it renews.

Observed in production: continuous `401 / refresh_token_invalidated` across two
hosts for ~9 days, with every `provider: openai` row frozen, **while the
accounts themselves were entirely healthy**. Running a current `codex`
refreshed `auth.json` in place and returned live usage immediately. The app was
reporting its own staleness as an account failure.

## What changed

- **`docs/spikes/2026-07-30-codex-usage-probe.md`** — new `Supersession
  (2026-08-15)` section, marked authoritative. Records that `codex app-server`
  exposes `account/read` + `account/rateLimits/read` over stdio JSON-RPC with
  Codex owning the credential; that `CODEX_HOME` scopes it per account (and is
  why multi-account never worked — `codex login` writes one `auth.json` per
  home); and the version constraint (absent in codex 0.46.0, verified on
  0.147.0).
- **`docs/spikes/README.md`** — index outcome and reading guide updated for the
  third layer.
- **`README.md`** — the existing rotation note prescribed re-syncing the
  credential between hosts via `accounts export`/`import`. That loop does not
  converge; amended to say so, and to say plainly not to copy OpenAI
  credentials between machines.

## Notes for review

- The live-verification section is **not** contradicted and is explicitly
  called out as still binding — it is now the fallback wire contract, and
  `OpenAIAPI.swift` / `RateLimitWindow.swift` still cite it correctly. Its two
  substantive findings (derive window kind from duration; a session window may
  legitimately be absent) are reinforced by the `app-server` shape, not
  replaced.
- Rotation itself was already documented in the README as verified 2026-07-31.
  What is new here is the *consequence* in sustained multi-host use, and the
  supersession says so rather than claiming a fresh discovery.
- All sample payloads are redacted (`<n>`, `<epoch>`, `<plan>`); no emails,
  hostnames, account ids, or tokens appear in the diff.

Implementation is tracked separately in #102 (app-server client), #103
(per-account `CODEX_HOME`), #104 (retire stored OpenAI tokens). This PR only
stops the docs from recommending the design those issues remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)