### PR TITLE
chore: configure Dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+# Only `github-actions` is configured, deliberately.
+#
+# The Swift package has zero package dependencies (see Package.swift), and the
+# root package.json is an empty Loom workspace shim with no dependency blocks
+# and no lockfile — neither gives Dependabot anything to update. The repo's
+# entire third-party surface is the actions referenced by .github/workflows.
+#
+# Actions are grouped including majors: they are low-risk here and reviewing
+# each bump as its own PR is noise. If a risk-bearing action is added later
+# (one coupled to an external binary or service), give it its own PR via
+# `exclude-patterns` rather than widening this group.
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+    labels: ["tier:maintenance"]


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml`, which the repo did not have — so no version updates were configured at all.

Scaffolded from what the repo actually contains, not a template.

## Why only `github-actions`

| Manifest | Ecosystem | Verdict |
|---|---|---|
| `.github/workflows/build.yml` | github-actions | **scaffolded** — 2× `actions/checkout@v5` |
| `package.json` (root) | npm | **excluded** — empty Loom workspace shim: `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies` all null, and no lockfile |
| `Package.swift` | — | **excluded** — zero package dependencies by design |

`.loom/` is an installer-owned tool root (`install-metadata.json`), but carries no manifests, so nothing was excluded on that basis. Its dependencies are `/repo:update-tools`' concern, not Dependabot's.

Honest scope: the entire third-party surface is one action, already on the current major. This is upkeep — it catches future `v5.x` patches and the eventual v6 — not a fix for anything broken today.

## Choices worth reviewing

- **Majors are grouped** for Actions. The general policy keeps package-ecosystem majors ungrouped so a breaking change gets its own reviewable PR, but Actions are low-risk and per-bump PRs are noise. The comment in the file records what to do if a risk-bearing action is ever added (`exclude-patterns`, its own PR).
- **`labels: ["tier:maintenance"]`**. Every `loom:*` workflow label carries an `Applied by:` reservation (Builder, Judge, Curator, Champion, …), so all are off-limits to a bot — applying a claim label would feed automation that acts on that claim. `tier:maintenance` is unrestricted. **No label was created.**

## Also done outside this PR (repo settings, not files)

Two repository flags were enabled — they are independent of this file and can't be set by it:

- vulnerability alerts: `404 → 204` (was disabled)
- `dependabot_security_updates`: `disabled → enabled`

## Note on Loom interaction

Dependabot PRs carry no `loom:` label, so `/loom:sweep` skips them and Champion will not auto-merge them. That is safe and probably correct, but it means nothing in the Loom pipeline watches these PRs — they will sit open until triaged by a human or `/repo:deps`. Deliberately not "fixed" by labelling bot PRs; routing them into auto-merge is a policy call, not a side effect of a hygiene command.

Dependabot fires on config merge rather than waiting for the weekly interval, so any first PR should appear within minutes of this landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)