### PR TITLE
fix: delete an account's credential rows when the account is removed

### DIFF
--- a/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
+++ b/menubar-app/ClaudeMonitor/Sources/SelfTest.swift
@@ -70,6 +70,8 @@ enum SelfTest {
         testParseAccountPairsRoundTripsOpenAIFields()
         testAccountSyncImportIsProviderScoped()
         testMergeDuplicateAccountsSharingEmail()
+        testAccountDeletionRemovesCredentials()
+        testPurgeOrphanedCredentialsMigration()
 
         if let idx = arguments.firstIndex(of: "--db"), idx + 1 < arguments.count {
             testMigrationOfExistingDatabase(at: arguments[idx + 1])
@@ -1060,6 +1062,258 @@ enum SelfTest {
         }
     }
 
+    // MARK: - Account removal vs. history clear (#106)
+
+    /// Removing an account must take its credential with it. Before #106 the
+    /// removal path deleted only `usage_history` and `accounts`, stranding a
+    /// plaintext OAuth token under an account id nothing in the app could
+    /// reach — never surfaced, never rotated, never revoked.
+    ///
+    /// The same function also backed the chart window's "Clear History"
+    /// button, so that control silently deleted the account too. The two are
+    /// now separate operations and this test pins both halves: delete removes
+    /// everything, clear-history removes only the time series.
+    private static func testAccountDeletionRemovesCredentials() {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("claude-monitor-selftest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let dbPath = dir.appendingPathComponent("usage.db").path
+
+            let store = UsageStore(dbPath: dbPath)
+            store.ensureDatabase()
+            let db = try openDatabase(dbPath)
+
+            let doomedId = "acct-doomed"
+            let keptId = "acct-kept"
+            // A third account with no credential at all — deleting it must be
+            // a clean no-op on `oauth_credentials`, not an error.
+            let bareId = "acct-bare"
+
+            for (id, email) in [(doomedId, "doomed@example.com"),
+                                (keptId, "kept@example.com"),
+                                (bareId, "bare@example.com")] {
+                try db.run("""
+                    INSERT INTO accounts (id, account_name, email, plan, last_updated, provider)
+                    VALUES (?, ?, ?, 'Max', '2026-06-01T00:00:00Z', 'anthropic')
+                """, id, email, email)
+            }
+
+            for id in [doomedId, keptId] {
+                try db.run("""
+                    INSERT INTO usage_history (account_id, timestamp, primary_percent, is_synthetic)
+                    VALUES (?, '2026-06-01T00:00:00Z', 12, 0)
+                """, id)
+                try db.run("""
+                    INSERT INTO probe_snapshots (account_id, timestamp, probe_model, http_status, headers)
+                    VALUES (?, '2026-06-01T00:00:00Z', 'haiku', 200, '{}')
+                """, id)
+                try db.run("""
+                    INSERT INTO named_limits (account_id, timestamp, limit_name, used_percent)
+                    VALUES (?, '2026-06-01T00:00:00Z', 'GPT-5.3-Codex-Spark', 42)
+                """, id)
+                try db.run("""
+                    INSERT INTO oauth_credentials
+                        (account_id, label, source, provider, access_token, refresh_token,
+                         is_active, created_at, updated_at)
+                    VALUES (?, 'label', 'token', 'anthropic', 'token-value', 'refresh-value', 1,
+                            '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z')
+                """, id)
+            }
+            // Two credentials share the doomed account id — both must go.
+            try db.run("""
+                INSERT INTO oauth_credentials
+                    (account_id, label, source, provider, access_token, is_active,
+                     created_at, updated_at)
+                VALUES (?, 'second', 'token', 'anthropic', 'second-token-value', 0,
+                        '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z')
+            """, doomedId)
+            // The user had pinned the account they are about to remove.
+            try db.run("INSERT INTO settings (key, value) VALUES ('primary_account_id', ?)", doomedId)
+
+            // --- Remove Account. ---
+            store.deleteAccount(accountId: doomedId)
+
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM accounts WHERE id = ?", doomedId) as? Int64, 0,
+                "removing an account deletes its accounts row")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM oauth_credentials WHERE account_id = ?",
+                              doomedId) as? Int64,
+                0, "removing an account deletes every one of its credential rows")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM usage_history WHERE account_id = ?",
+                              doomedId) as? Int64,
+                0, "removing an account deletes its usage_history rows")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM probe_snapshots WHERE account_id = ?",
+                              doomedId) as? Int64,
+                0, "removing an account deletes its probe_snapshots rows")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM named_limits WHERE account_id = ?",
+                              doomedId) as? Int64,
+                0, "removing an account deletes its named_limits rows")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM settings WHERE key = 'primary_account_id'")
+                    as? Int64,
+                0, "removing the pinned account clears the primary-account pin")
+
+            // The detection query from the issue: no credential may reference
+            // a missing account after a delete.
+            expectEqual(try orphanedCredentialCount(db), 0,
+                        "an account delete leaves no orphaned credential rows")
+
+            // Deleting an account that never had a credential is a clean no-op.
+            store.deleteAccount(accountId: bareId)
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM accounts WHERE id = ?", bareId) as? Int64, 0,
+                "an account with no credential still deletes cleanly")
+            expectEqual(try orphanedCredentialCount(db), 0,
+                        "deleting a credential-less account leaves no orphans")
+
+            // The untouched account keeps everything.
+            expectEqual(
+                try db.scalar("SELECT access_token FROM oauth_credentials WHERE account_id = ?",
+                              keptId) as? String,
+                "token-value", "the other account's credential is untouched by the delete")
+
+            // --- Clear History (chart window). ---
+            store.clearAccountHistory(accountId: keptId)
+
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM accounts WHERE id = ?", keptId) as? Int64, 1,
+                "clearing history does NOT delete the accounts row")
+            expectEqual(
+                try db.scalar("SELECT access_token FROM oauth_credentials WHERE account_id = ?",
+                              keptId) as? String,
+                "token-value", "clearing history does NOT touch the credential")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM usage_history WHERE account_id = ?",
+                              keptId) as? Int64,
+                0, "clearing history empties usage_history")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM probe_snapshots WHERE account_id = ?",
+                              keptId) as? Int64,
+                0, "clearing history empties the probe archive")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM named_limits WHERE account_id = ?",
+                              keptId) as? Int64,
+                0, "clearing history empties the named-limit series")
+            expectEqual(try orphanedCredentialCount(db), 0,
+                        "clearing history leaves no orphaned credential rows")
+        } catch {
+            checks += 1
+            failures.append("account deletion test threw: \(error)")
+        }
+    }
+
+    /// The healing migration for databases that already carry an orphan from a
+    /// pre-#106 build. Two properties matter as much as the purge itself:
+    /// credentials with a NULL (or blank) `account_id` must **survive** — the
+    /// column is nullable, and the obvious `LEFT JOIN accounts … WHERE a.id IS
+    /// NULL` predicate would silently destroy live token material — and a
+    /// second run must be a no-op.
+    private static func testPurgeOrphanedCredentialsMigration() {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("claude-monitor-selftest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let dbPath = dir.appendingPathComponent("usage.db").path
+
+            let store = UsageStore(dbPath: dbPath)
+            store.ensureDatabase()
+            let db = try openDatabase(dbPath)
+
+            try db.run("""
+                INSERT INTO accounts (id, account_name, email, plan, last_updated, provider)
+                VALUES ('live-account', 'live@example.com', 'live@example.com', 'Max',
+                        '2026-06-01T00:00:00Z', 'anthropic')
+            """)
+            // Belongs to a live account — must be left alone.
+            try db.run("""
+                INSERT INTO oauth_credentials
+                    (account_id, label, source, provider, access_token, is_active,
+                     created_at, updated_at)
+                VALUES ('live-account', 'live', 'token', 'anthropic', 'live-token', 1,
+                        '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z')
+            """)
+            // The orphan a pre-#106 removal left behind, token still populated.
+            try db.run("""
+                INSERT INTO oauth_credentials
+                    (account_id, label, source, provider, access_token, refresh_token, is_active,
+                     created_at, updated_at)
+                VALUES ('gone-account', 'gone', 'token', 'anthropic', 'stranded-token',
+                        'stranded-refresh', 0, '2026-02-10T17:16:25Z', '2026-07-22T04:25:07Z')
+            """)
+            // Never attached to an account. `account_id` is nullable, so these
+            // are legitimate rows — the purge must not reach them.
+            try db.run("""
+                INSERT INTO oauth_credentials
+                    (account_id, label, source, provider, access_token, is_active,
+                     created_at, updated_at)
+                VALUES (NULL, 'unattached', 'keychain', 'anthropic', 'null-account-token', 1,
+                        '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z')
+            """)
+            try db.run("""
+                INSERT INTO oauth_credentials
+                    (account_id, label, source, provider, access_token, is_active,
+                     created_at, updated_at)
+                VALUES ('   ', 'blank', 'keychain', 'anthropic', 'blank-account-token', 1,
+                        '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z')
+            """)
+
+            expectEqual(try db.scalar("SELECT COUNT(*) FROM oauth_credentials") as? Int64, 4,
+                        "the seeded database starts with four credential rows")
+
+            // --- What the next launch does. ---
+            store.ensureDatabase()
+
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM oauth_credentials WHERE account_id = 'gone-account'")
+                    as? Int64,
+                0, "the migration purges the orphaned credential")
+            expectEqual(try orphanedCredentialCount(db), 0,
+                        "the detection query reports no orphans after the migration")
+            expectEqual(
+                try db.scalar("SELECT access_token FROM oauth_credentials WHERE account_id = 'live-account'")
+                    as? String,
+                "live-token", "a credential belonging to a live account is untouched")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM oauth_credentials WHERE account_id IS NULL")
+                    as? Int64,
+                1, "a credential with account_id IS NULL survives the purge")
+            expectEqual(
+                try db.scalar("SELECT COUNT(*) FROM oauth_credentials WHERE TRIM(account_id) = ''")
+                    as? Int64,
+                1, "a credential with a blank account_id survives the purge")
+            expectEqual(try db.scalar("SELECT COUNT(*) FROM oauth_credentials") as? Int64, 3,
+                        "exactly one row — the orphan — is removed")
+
+            // Idempotent: re-running over the healed database changes nothing.
+            store.ensureDatabase()
+            expectEqual(try db.scalar("SELECT COUNT(*) FROM oauth_credentials") as? Int64, 3,
+                        "re-running the migration on a healed database is a no-op")
+        } catch {
+            checks += 1
+            failures.append("orphaned credential purge test threw: \(error)")
+        }
+    }
+
+    /// The issue's detection query, narrowed the same way the purge predicate
+    /// is: credential rows whose `account_id` *names* an account that isn't
+    /// there. A NULL or blank `account_id` is not an orphan — it was never
+    /// attached to an account — so those rows are excluded here and asserted
+    /// to survive separately by the callers above.
+    private static func orphanedCredentialCount(_ db: Connection) throws -> Int64 {
+        try db.scalar("""
+            SELECT COUNT(*) FROM oauth_credentials c
+            LEFT JOIN accounts a ON a.id = c.account_id
+            WHERE a.id IS NULL AND c.account_id IS NOT NULL AND TRIM(c.account_id) != ''
+        """) as? Int64 ?? -1
+    }
+
     // MARK: - Schema migration
 
     /// Builds a database with the *pre-#28* schema, populates it the way a real
@@ -1372,6 +1626,11 @@ enum SelfTest {
                 "SELECT COUNT(*) FROM accounts WHERE provider IS NULL OR TRIM(provider) = ''"
             ) as? Int64
             expectEqual(stray, 0, "--db: no account left without a provider")
+            // #106: the healing purge must have cleared any credential row
+            // stranded by a pre-fix account removal. Count only — a real
+            // database's ids, labels, emails, and tokens are never printed.
+            expectEqual(try orphanedCredentialCount(db), 0,
+                        "--db: no orphaned credential rows left after migration")
             print("selftest --db: migrated \(store.accounts.count) account(s) at \(path)")
         } catch {
             checks += 1

--- a/menubar-app/ClaudeMonitor/Sources/UsageChartView.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageChartView.swift
@@ -666,7 +666,9 @@ struct UsageChartWindow: View {
         .alert("Clear History?", isPresented: $showClearConfirmation) {
             Button("Cancel", role: .cancel) { }
             Button("Clear", role: .destructive) {
-                store.clearAccountData(accountId: account.id)
+                // History only — the account and its credential stay, which is
+                // what this alert has always promised (#106).
+                store.clearAccountHistory(accountId: account.id)
                 // Close this window
                 if let window = ChartWindowController.windows[account.id] {
                     window.close()

--- a/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsagePopoverView.swift
@@ -606,7 +606,7 @@ struct UsagePopoverView: View {
                 }
             }
         } message: {
-            Text("This will deactivate the credential and remove usage data for \(accountToRemove?.displayName ?? "this account").")
+            Text("This will delete the stored credential and all usage data for \(accountToRemove?.displayName ?? "this account").")
         }
     }
 
@@ -616,12 +616,13 @@ struct UsagePopoverView: View {
         return "\(formatInterval(seconds)) ago"
     }
 
+    /// Removes the account and everything keyed to it — including its
+    /// credential rows, which `deleteAccount` deletes outright. The previous
+    /// `deactivateCredential` pass this used to make is gone with them: it
+    /// only flipped `is_active = 0` and left the plaintext token on disk
+    /// under an account row that was about to disappear (#106).
     private func removeAccount(_ account: Account) {
-        let credentials = oauthPoller.loadActiveCredentials()
-        for cred in credentials where cred.accountId == account.id {
-            oauthPoller.deactivateCredential(cred)
-        }
-        store.clearAccountData(accountId: account.id)
+        store.deleteAccount(accountId: account.id)
     }
 
     // MARK: - Copy / Paste Accounts

--- a/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
+++ b/menubar-app/ClaudeMonitor/Sources/UsageStore.swift
@@ -385,6 +385,55 @@ class UsageStore: ObservableObject {
         // rows polling the same account independently (#45). Must run after
         // the email backfill above so a row healed there is eligible too.
         mergeDuplicateAccountsSharingEmail(db)
+
+        // Migration: delete credential rows whose account row is gone (#106).
+        // Pre-fix builds removed an account without its credential, stranding
+        // a plaintext token that no UI or export can reach (every one of them
+        // joins through `accounts`) — so it is never surfaced, rotated, or
+        // revoked. Must run *after* the merge above, which can itself delete
+        // an account row in the same pass.
+        purgeOrphanedCredentials(db)
+    }
+
+    /// Deletes `oauth_credentials` rows that reference an account which no
+    /// longer exists. Idempotent: a second run finds nothing left to delete.
+    ///
+    /// The declared `FOREIGN KEY (account_id) REFERENCES accounts(id)` does
+    /// not do this for us — SQLite defaults `PRAGMA foreign_keys` to OFF and
+    /// this app only ever sets `journal_mode`, so every FK in the schema is
+    /// documentation rather than enforcement.
+    ///
+    /// **The NULL/blank guard is load-bearing.** `account_id` is nullable, so
+    /// the obvious `LEFT JOIN accounts … WHERE a.id IS NULL` predicate also
+    /// matches rows that were never attached to an account — deleting those
+    /// would be an unrecoverable loss of live token material. `NOT EXISTS`
+    /// plus the explicit `IS NOT NULL` / non-blank test keeps them.
+    // Pure function of its `db` argument — touches no instance/class
+    // main-actor state, so it stays callable from the CLI/headless paths.
+    private nonisolated static func purgeOrphanedCredentials(_ db: Connection) {
+        // Counted before the delete because the SQLite wrapper here exposes no
+        // `sqlite3_changes`. Logged as a bare count — never an id, label,
+        // email, or token fragment.
+        let orphanPredicate = """
+            account_id IS NOT NULL
+              AND TRIM(account_id) != ''
+              AND NOT EXISTS (SELECT 1 FROM accounts a WHERE a.id = oauth_credentials.account_id)
+            """
+        do {
+            let count = try db.scalar(
+                "SELECT COUNT(*) FROM oauth_credentials WHERE \(orphanPredicate)") as? Int64 ?? 0
+            guard count > 0 else { return }
+            try db.run("DELETE FROM oauth_credentials WHERE \(orphanPredicate)")
+            FileLogger.shared.info(
+                "purgeOrphanedCredentials: purged \(count) orphaned credential row(s)",
+                category: "DB"
+            )
+        } catch {
+            FileLogger.shared.error(
+                "purgeOrphanedCredentials: purge failed: \(error)",
+                category: "DB"
+            )
+        }
     }
 
     /// Adds a column only when it isn't already there. `ALTER TABLE ... ADD
@@ -1071,25 +1120,90 @@ class UsageStore: ObservableObject {
         }
     }
 
-    func clearAccountData(accountId: String) {
+    /// Clears an account's recorded time series and nothing else — the
+    /// account row, its credential, and its settings pin all survive, so the
+    /// account keeps appearing in the popover and keeps polling.
+    ///
+    /// This is what the chart window's "Clear History?" affordance promises.
+    /// Before #106 it shared an implementation with account removal and so
+    /// silently deleted the `accounts` row too, leaving an `is_active = 1`
+    /// credential the poller kept using for an account that no longer existed.
+    func clearAccountHistory(accountId: String) {
         do {
             guard FileManager.default.fileExists(atPath: dbPath) else {
                 return
             }
 
             let db = try openDatabase(dbPath)
-
-            // Delete usage history for this account, then the account itself
+            // Every per-account time series the chart draws from: the usage
+            // points themselves, the raw probe archive behind them, and the
+            // provider-named limit series.
             try db.run("DELETE FROM usage_history WHERE account_id = ?", accountId)
-            try db.run("DELETE FROM accounts WHERE id = ?", accountId)
+            try db.run("DELETE FROM probe_snapshots WHERE account_id = ?", accountId)
+            try db.run("DELETE FROM named_limits WHERE account_id = ?", accountId)
 
             // Reload to reflect the change
             loadFromDatabase()
 
         } catch {
             DispatchQueue.main.async {
-                self.error = "Failed to clear account data: \(error.localizedDescription)"
+                self.error = "Failed to clear account history: \(error.localizedDescription)"
             }
+        }
+    }
+
+    /// Removes an account completely: its time series, its credential rows,
+    /// its settings pin, and finally the account row itself.
+    ///
+    /// Deleting the credential in the *same* operation is the fix for #106 —
+    /// a partial delete strands a plaintext OAuth token that nothing in the
+    /// app can see (every UI/export query joins through `accounts`), so it is
+    /// never rotated and never revoked.
+    func deleteAccount(accountId: String) {
+        do {
+            guard FileManager.default.fileExists(atPath: dbPath) else {
+                return
+            }
+
+            let db = try openDatabase(dbPath)
+            try UsageStore.deleteAccountRows(db, accountId: accountId)
+
+            // Reload to reflect the change
+            loadFromDatabase()
+
+        } catch {
+            DispatchQueue.main.async {
+                self.error = "Failed to remove account: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    /// Deletes every row keyed to `accountId` across the schema, inside a
+    /// transaction so a mid-delete failure can't leave the exact half-applied
+    /// state this function exists to prevent (an orphaned credential). Mirrors
+    /// `mergeAccountRow`'s BEGIN/COMMIT-or-ROLLBACK shape.
+    // Pure function of its arguments — touches no instance/class main-actor
+    // state, matching `mergeAccountRow`, so the row-level work stays callable
+    // from non-UI contexts.
+    private nonisolated static func deleteAccountRows(_ db: Connection, accountId: String) throws {
+        do {
+            try db.execute("BEGIN")
+            try db.run("DELETE FROM usage_history WHERE account_id = ?", accountId)
+            try db.run("DELETE FROM probe_snapshots WHERE account_id = ?", accountId)
+            try db.run("DELETE FROM named_limits WHERE account_id = ?", accountId)
+            // The credential goes with the account. Deactivating it instead
+            // (what the popover used to do before calling this) leaves the
+            // token on disk forever.
+            try db.run("DELETE FROM oauth_credentials WHERE account_id = ?", accountId)
+            // Don't leave the user's "primary" pin dangling at a row that no
+            // longer exists, mirroring the merge path.
+            try db.run("DELETE FROM settings WHERE key = ? AND value = ?",
+                       primaryAccountSettingKey, accountId)
+            try db.run("DELETE FROM accounts WHERE id = ?", accountId)
+            try db.execute("COMMIT")
+        } catch {
+            try? db.execute("ROLLBACK")
+            throw error
         }
     }
 


### PR DESCRIPTION
## Summary

Removing an account deleted only its `usage_history` and `accounts` rows, stranding an `oauth_credentials` row that still holds a plaintext OAuth token. Nothing in the app can reach that row (every UI query and export joins through `accounts`), so the token is never surfaced, never rotated, and never revoked. The declared `FOREIGN KEY (account_id) REFERENCES accounts(id)` does not help — SQLite defaults `PRAGMA foreign_keys` to OFF and this app only ever sets `journal_mode`, so every FK in the schema is documentation rather than enforcement.

The defective function, `clearAccountData`, also backed a **second, differently-intended** affordance: the chart window's "Clear History?" alert. Adding a credential delete to it would have made that button destroy the user's token — strictly worse than the bug being fixed. So the function is split rather than patched.

## Changes

**`Sources/UsageStore.swift`**

- `clearAccountData` → split into two operations:
  - `clearAccountHistory(accountId:)` — deletes the per-account time series only (`usage_history`, `probe_snapshots`, `named_limits`). The `accounts` row, its credential, and the settings pin all survive.
  - `deleteAccount(accountId:)` — deletes the time series, **the credential rows**, the `primary_account_id` pin, and finally the `accounts` row, via a new `private nonisolated static deleteAccountRows` helper wrapped in `BEGIN`/`COMMIT`-or-`ROLLBACK` (mirroring `mergeAccountRow`), so a mid-delete failure cannot produce the exact half-applied state this fixes.
- New `purgeOrphanedCredentials(_:)`, called from `applySchema` **after** `mergeDuplicateAccountsSharingEmail` (which can itself delete an account row in the same pass). Idempotent, and heals in place on every launch/CLI path per the established `#15`/`#23` pattern.
  - **The NULL/blank guard is load-bearing**: `account_id` is nullable, and the obvious `LEFT JOIN accounts … WHERE a.id IS NULL` predicate also matches credentials that were never attached to an account — deleting those is unrecoverable token loss. The predicate is `NOT EXISTS` plus explicit `IS NOT NULL` / `TRIM(...) != ''` tests.
  - Logs a **bare count** only. No id, label, email, or token fragment.

**`Sources/UsageChartView.swift`** — "Clear History?" now calls `clearAccountHistory`. It previously deleted the `accounts` row behind the user's back and, unlike the popover path, did not deactivate the credential — leaving an `is_active = 1` orphan that `OAuthPoller.loadActiveCredentials` (no join to `accounts`) kept polling forever for an account that no longer existed.

**`Sources/UsagePopoverView.swift`** — "Remove Account" now calls `deleteAccount`. Its previous `deactivateCredential` loop is removed: it only flipped `is_active = 0` and left the plaintext token on disk. The alert text now says the credential is *deleted* rather than *deactivated*, matching what happens.

**`Sources/SelfTest.swift`** — two new test functions plus an assertion on the `--db` real-database path.

Not touched, per the issue's scope guard: `AccountSync.swift`, `SQLiteDB.swift` (owned by #105), `OAuthPoller.swift` (no change needed).

## Acceptance Criteria Verification

- [x] **Root cause fixed at source** — `deleteAccount` deletes `oauth_credentials` in the same transaction as `accounts`; the migration is additive healing, not the fix.
- [x] **`clearAccountData` is split** into `clearAccountHistory` + `deleteAccount`, and both callers rewired to the one matching their alert text.
- [x] **Chart "Clear History" no longer deletes the `accounts` row or the credential** — asserted directly (`clearing history does NOT delete the accounts row`, `... does NOT touch the credential`).
- [x] **Popover "Remove Account" leaves no orphan** in `oauth_credentials`, `probe_snapshots`, or `named_limits`; the detection query returns 0 immediately afterward — asserted.
- [x] **Idempotent healing migration** in `applySchema`; a second `ensureDatabase()` is asserted to be a no-op.
- [x] **The purge does not delete credentials whose `account_id` IS NULL or blank** — both cases seeded with populated tokens and asserted to survive.
- [x] **`selftest` fails if a delete leaves an orphaned credential** — verified by temporarily reverting the fix (see TDD below), not by inspection.
- [x] **Verified against a copy of a real database** — detection query went `1 → 0`, `oauth_credentials` `21 → 20`, `accounts` unchanged at `20`, and every remaining account still has its credential.
- [x] **No token, refresh token, or email in any added log line** — the single new log line interpolates an `Int64` count and nothing else.

## Test Plan

**TDD:** Both new tests were confirmed to fail against the pre-fix behavior before being accepted, by temporarily removing the fix and rebuilding:

- With `DELETE FROM oauth_credentials` removed from `deleteAccountRows` — 4 failures, including `removing an account deletes every one of its credential rows: expected Optional(0), got Optional(2)` and `an account delete leaves no orphaned credential rows: expected 0, got 2`.
- With the `purgeOrphanedCredentials(db)` call removed from `applySchema` — 4 failures, including `the migration purges the orphaned credential: expected Optional(0), got Optional(1)` and `re-running the migration on a healed database is a no-op: expected Optional(3), got Optional(4)`.

Both edits were reverted and the suite returns to green.

- `swift build && .build/debug/ClaudeMonitor selftest` → `selftest: 194 check(s) passed`, exit 0 (was 186 checks on main).
  - `testAccountDeletionRemovesCredentials`: full delete clears all four per-account tables + the settings pin; two credentials sharing one `account_id` both go; an account with **no** credential deletes cleanly; a sibling account is untouched; then history-clear keeps the account row and its token while emptying the three time-series tables.
  - `testPurgeOrphanedCredentialsMigration`: seeds a live-account credential, an orphan with a populated token, a `NULL`-`account_id` row, and a blank-`account_id` row → only the orphan is removed (4 → 3 rows), and a second `ensureDatabase()` changes nothing.
- **Migration against real data**, per CLAUDE.md (copy first; `--db` writes):
  ```
  cp ~/.claude-monitor/usage.db <scratch>/orphan-check.db
  .build/debug/ClaudeMonitor selftest --db <scratch>/orphan-check.db
  ```
  Before: `orphans=1, oauth_credentials=21, accounts=20`. After: `orphans=0, oauth_credentials=20, accounts=20`, and `accounts` with no credential = `0` (no live account lost its token). The scratch copy was deleted afterward; no token or email value was read or printed.
- **Linux**: not run locally — Docker is unavailable on this host. `UsageStore.swift` is portable core and the change adds no AppKit/SwiftUI/Combine/`os.Logger` usage (only existing `Foundation`/`Dispatch` idioms already present in the file); the two view files are already macOS-fenced. CI runs `selftest` on Linux and is authoritative.

### Pre-existing failure, unrelated to this PR

`selftest --db` reports one failure on this host **on `main` as well** (verified at `5808e88`): `--db: every pre-existing account backfilled to anthropic`. The host's database legitimately contains 1 `openai` account alongside 19 `anthropic` ones, so that assertion in `testMigrationOfExistingDatabase` is over-strict since multi-provider support landed. Left alone as out of scope; worth a separate issue. The default `selftest` (no `--db`) is fully green.

Closes #106