### PR TITLE
chore: sync User-Agent to claude-code 2.1.224

### DIFF
--- a/menubar-app/ClaudeMonitor/Sources/AnthropicAPI.swift
+++ b/menubar-app/ClaudeMonitor/Sources/AnthropicAPI.swift
@@ -7,7 +7,7 @@ private let flog = FileLogger.shared
 private let fcat = "API"
 
 // Auto-updated by build script from installed claude-code version
-private let claudeCodeUserAgent = "claude-code/2.1.212"
+private let claudeCodeUserAgent = "claude-code/2.1.224"
 
 // MARK: - Ping Response (parsed from rate-limit headers)
 


### PR DESCRIPTION
## Summary

One-line change to `claudeCodeUserAgent`: `claude-code/2.1.212` → `claude-code/2.1.224`.

Not hand-written. `scripts/build-macos-app.sh` detects the `claude-code` version on PATH and `sed -i ''`-patches this constant before compiling, without restoring it afterwards — so any local `./scripts/build-macos-app.sh` run leaves exactly this diff in the working tree. CLAUDE.md documents the patching as intended behavior; this PR is just landing the result so it does not sit loose in the main checkout.

Produced by a build on a host running Claude Code `2.1.224`.

## Why it matters

`AnthropicAPI` sends this string as the `User-Agent` on every polling request, so it should track the Claude Code version the app is imitating rather than drift behind it. It is also the one file a build reliably dirties, which makes it a recurring source of "unexpected uncommitted change" in a repo where sweeps run `check-main-clean.sh --quarantine` against a pre-build baseline.

## Verification

- `swift build && .build/debug/ClaudeMonitor selftest` → 327 checks pass
- Bundle built from this tree launches and polls normally; Codex accounts resolve over `codex app-server` and Anthropic accounts poll unchanged
- No behavior change beyond the header value

## Note for reviewers

This will recur on every build made against a newer Claude Code. If that churn is unwanted, the durable fix is for the build script to restore the file afterwards (and read the version at runtime instead), but that is a change to the build script's documented contract and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)